### PR TITLE
Filter 'and' logic

### DIFF
--- a/src/app/components/Book/Book.jsx
+++ b/src/app/components/Book/Book.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import config from '../../../../appConfig.js';
+import utils from '../../utils/utils';
 
 const Book = ({ book }) => {
   const bookImgSrc = book.imageSlug || 'No Image';
@@ -9,7 +10,7 @@ const Book = ({ book }) => {
     'https://contentcafe2.btol.com/ContentCafe/Jacket.aspx?&userID=NYPL49807' +
     `&password=CC68707&Value=${bookImgSrc}&content=M&Return=1&Type=M`
     : `${config.baseUrl}src/client/images/book-place-holder.png`;
-  const tagArray = book.tags.map(tag => tag.toLowerCase().split(' ').join('-'));
+  const tagArray = utils.getPickTags(book);
   const tagClasses = tagArray.join(' ');
 
   return (

--- a/src/app/components/BookList/BookList.jsx
+++ b/src/app/components/BookList/BookList.jsx
@@ -1,28 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import Book from '../Book/Book.jsx';
-import {
-  contains as _contains,
-  each as _each,
-} from 'underscore';
+import utils from '../../utils/utils';
 
 const Books = (props) => {
   const currentMonthPicks = props.currentMonthPicks;
   const picks = currentMonthPicks.picks ? currentMonthPicks.picks : [];
   const filteredBooks = props.selectedFilters.length ?
     picks.filter(book => {
-      const tagArray = book.tags.map(tag => tag.toLowerCase().split(' ').join('-'));
-      const inSelectedFilter = [];
-      _each(tagArray, (bookTag) => {
-        if (_contains(props.selectedFilters, bookTag)) {
-          inSelectedFilter.push(bookTag);
-        }
-      });
+      const tagArray = utils.getPickTags(book);
+      const inSelectedFilter = utils.getSelectedTags(tagArray, props.selectedFilters);
 
-      console.log(inSelectedFilter);
-      if (inSelectedFilter.length) {
+      if (inSelectedFilter.length && (inSelectedFilter.length === props.selectedFilters.length)) {
         return book;
       }
+
+      return undefined;
     })
     : picks;
 

--- a/src/app/components/BookList/BookList.jsx
+++ b/src/app/components/BookList/BookList.jsx
@@ -13,7 +13,9 @@ const BookList = (props) => {
       // Only execute filtering if the selectedFilters object is not empty
       if (selectedFilters.length) {
         return pickItems.filter(book => {
+          // Get the pick's tags in an ID readable array
           const tagArray = utils.getPickTags(book);
+          // Get the array of selected tags found in the book item
           const inSelectedFilter = utils.getSelectedTags(tagArray, props.selectedFilters);
 
           if (inSelectedFilter.length &&
@@ -24,7 +26,7 @@ const BookList = (props) => {
           return undefined;
         });
       }
-      // No filters, return original pick
+      // No filters, return original picks
       return pickItems;
     }
     return pickItems;
@@ -50,7 +52,7 @@ BookList.propTypes = {
 };
 
 BookList.defaultProps = {
-  className: 'Books',
+  className: 'booklist',
   lang: 'en',
 };
 

--- a/src/app/components/BookList/BookList.jsx
+++ b/src/app/components/BookList/BookList.jsx
@@ -16,10 +16,10 @@ const BookList = (props) => {
           // Get the pick's tags in an ID readable array
           const tagArray = utils.getPickTags(book);
           // Get the array of selected tags found in the book item
-          const inSelectedFilter = utils.getSelectedTags(tagArray, props.selectedFilters);
+          const inSelectedFilter = utils.getSelectedTags(tagArray, selectedFilters);
 
           if (inSelectedFilter.length &&
-              (inSelectedFilter.length === props.selectedFilters.length)) {
+              (inSelectedFilter.length === selectedFilters.length)) {
             return book;
           }
 

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -1,4 +1,8 @@
-import { union as _union } from 'underscore';
+import {
+  union as _union,
+  contains as _contains,
+  each as _each,
+} from 'underscore';
 
 import appConfig from '../../../appConfig.js';
 import { gaUtils } from 'dgx-react-ga';
@@ -17,6 +21,38 @@ function Utils() {
    * @param {string} label Label for GA event.
    */
   this.trackPicks = gaUtils.trackEvent('Staff Picks');
+
+  /**
+   * getPickTags(book)
+   * Return an array of the pick's tags, lowercased and with a hyphen to easily
+   * use as a class or an ID.
+   *
+   * @param {object} book
+   */
+  this.getPickTags = (book) => {
+    if (!(book.tags && book.tags.length)) {
+      return [];
+    }
+    return book.tags.map(tag => tag.toLowerCase().split(' ').join('-'));
+  };
+
+  /**
+   * getSelectedTags(tagArray, selectedFilters)
+   * Return an array of the filters in a pick's tagArray if the selectedFilters is found.
+   *
+   * @param {array} tagArray
+   * @param {array} selectedFilters
+   */
+  this.getSelectedTags = (tagArray, selectedFilters) => {
+    const inSelectedFilter = [];
+    _each(tagArray, (bookTag) => {
+      if (_contains(selectedFilters, bookTag)) {
+        inSelectedFilter.push(bookTag);
+      }
+    });
+
+    return inSelectedFilter;
+  };
 }
 
 export default new Utils();


### PR DESCRIPTION
Fixes #25 

Adds "AND" filtering. Example below based on not-so-good available data:

![screen shot 2017-10-24 at 12 12 09 pm](https://user-images.githubusercontent.com/1280564/31954919-db1343ea-b8b4-11e7-9b61-4b78168f0762.png)

You can try clicking on `adventure` `fantasy` `friendship` `funny`, in any order, and you should get that one book as a result "Pugs of the Frozen North...". If you do not get any results from a filter, it's because the data is not right - those tags there are not necessarily the tags we will used but are hardcoded until we get the right dataset.