### PR TITLE
Removing not available filters

### DIFF
--- a/src/app/actions/BookActions.js
+++ b/src/app/actions/BookActions.js
@@ -17,6 +17,10 @@ class Actions {
   setSelectedFilter(filterId, active) {
     return [filterId, active];
   }
+
+  setSelectableFilters(filters) {
+    return filters;
+  }
 }
 
 export default alt.createActions(Actions);

--- a/src/app/components/Application/Main.jsx
+++ b/src/app/components/Application/Main.jsx
@@ -3,21 +3,83 @@ import PropTypes from 'prop-types';
 
 import BookList from '../BookList/BookList.jsx';
 import Sidebar from '../Sidebar/Sidebar.jsx';
+import utils from '../../utils/utils';
 
-const App = (props) => (
-  <div className="nypl-row">
-    <Sidebar filters={props.filters} />
+class App extends React.Component {
+  constructor(props) {
+    super(props);
 
-    <BookList
-      currentMonthPicks={props.currentMonthPicks}
-      selectedFilters={props.selectedFilters}
-    />
-  </div>
-);
+    this.state = {
+      selectableFilters: this.props.selectableFilters,
+      selectedFilters: this.props.selectedFilters,
+      picks: this.props.currentMonthPicks.picks,
+    };
+
+    this.setSelectedFilter = this.setSelectedFilter.bind(this);
+  }
+
+  getNewPickSet(picks, selectedFilters) {
+    if (!selectedFilters.length) {
+      return picks;
+    }
+
+    return picks.filter(book => {
+      // Get the pick's tags in an ID readable array
+      const tagArray = utils.getPickTags(book);
+      // Get the array of selected tags found in the book item
+      const inSelectedFilter = utils.getSelectedTags(tagArray, selectedFilters);
+
+      if (inSelectedFilter.length &&
+          (inSelectedFilter.length === selectedFilters.length)) {
+        return book;
+      }
+
+      return undefined;
+    });
+  }
+
+  setSelectedFilter(filterId, active) {
+    let selectedFilters = [];
+
+    if (active) {
+      selectedFilters = this.state.selectedFilters.concat(filterId);
+    } else {
+      selectedFilters = this.state.selectedFilters.filter(f => f !== filterId);
+    }
+
+    const picks = this.getNewPickSet(this.props.currentMonthPicks.picks, selectedFilters);
+    const selectableFilters = utils.getSelectableTags(picks);
+
+    this.setState({
+      selectableFilters,
+      picks,
+      selectedFilters,
+    });
+  }
+
+  render() {
+    return (
+      <div className="nypl-row">
+        <Sidebar
+          filters={this.props.filters}
+          selectableFilters={this.state.selectableFilters}
+          setSelectedFilter={this.setSelectedFilter}
+        />
+
+        <BookList
+          picks={this.state.picks}
+          selectedFilters={this.state.selectedFilters}
+          setSelectableFilters={this.setSelectableFilters}
+        />
+      </div>
+    );
+  }
+}
 
 App.propTypes = {
   filters: PropTypes.array,
   selectedFilters: PropTypes.array,
+  selectableFilters: PropTypes.array,
   currentMonthPicks: PropTypes.object,
 };
 

--- a/src/app/components/BookFilters/BookFilters.jsx
+++ b/src/app/components/BookFilters/BookFilters.jsx
@@ -28,11 +28,10 @@ class BookFilters extends React.Component {
   }
 
   onClick(filterId, active) {
-    // const filterId = filter.toLowerCase().split(' ').join('-');
-    const f = _findWhere(this.state.filters, { id: filterId });
+    const foundFilter = _findWhere(this.state.filters, { id: filterId });
     // This is still the filter object from the state, but we just want to modify
     // its active property.
-    f.active = active;
+    foundFilter.active = active;
     this.props.setSelectedFilter(filterId, active);
 
     this.setState({

--- a/src/app/components/BookFilters/BookFilters.jsx
+++ b/src/app/components/BookFilters/BookFilters.jsx
@@ -5,6 +5,7 @@ import {
   contains as _contains,
   findWhere as _findWhere,
 } from 'underscore';
+
 import Filter from './Filter';
 
 class BookFilters extends React.Component {
@@ -12,41 +13,64 @@ class BookFilters extends React.Component {
     super(props);
 
     this.state = {
+      // Create an array data structure of filter objects.
       filters: this.props.filters.map(filter => ({
         active: false,
         id: filter.toLowerCase().split(' ').join('-'),
         label: filter,
       })),
+      focusId: '',
     };
 
     this.renderItems = this.renderItems.bind(this);
     this.onClick = this.onClick.bind(this);
+    this.getFilterArray = this.getFilterArray.bind(this);
   }
 
-  onClick(filter, active) {
-    const filterId = filter.toLowerCase().split(' ').join('-');
+  onClick(filterId, active) {
+    // const filterId = filter.toLowerCase().split(' ').join('-');
     const f = _findWhere(this.state.filters, { id: filterId });
-    // This is still the filter object from the state:
+    // This is still the filter object from the state, but we just want to modify
+    // its active property.
     f.active = active;
     this.props.setSelectedFilter(filterId, active);
 
-    this.setState({ filters: this.state.filters });
+    this.setState({
+      filters: this.state.filters,
+      focusId: filterId,
+    });
   }
 
-  renderItems(filters) {
-    const filtersToRender = this.props.selectableFilters.length ?
-      filters.filter(filter =>
-        _contains(this.props.selectableFilters, filter.id)
-      )
-      : filters;
+  /*
+   * getFilterArray(selectableFilters, filters)
+   * If the list of selectable filters is available, then we want the subset of all filters
+   * that can be selected. A selectable filter is based on whether or not it is available
+   * from a rendered pick item.
+   * @param {array} selectableFilters
+   * @param {array} filters
+   */
+  getFilterArray(selectableFilters, filters) {
+    if (!selectableFilters.length) {
+      return filters;
+    }
+    return filters.filter(filter => _contains(selectableFilters, filter.id));
+  }
 
-    return filtersToRender.map((filter, i) =>
-      <Filter key={i} filter={filter} onClick={this.onClick} />
+  /*
+   * renderItems(filters)
+   * Render the filter button list items.
+   * @param {array} filter
+   */
+  renderItems(filters) {
+    return filters.map((filter, i) =>
+      <Filter key={i} filter={filter} onClick={this.onClick} focusId={this.state.focusId} />
     );
   }
 
   render() {
-    const filters = this.state.filters;
+    const { filters } = this.state;
+    const { selectableFilters } = this.props;
+    const filtersToRender = this.getFilterArray(selectableFilters, filters);
 
     return (
       <div className="book-filters">
@@ -54,7 +78,7 @@ class BookFilters extends React.Component {
           <h2><FilterIcon />Filter by Tags</h2>
         </div>
         <ul>
-          {this.renderItems(filters)}
+          {this.renderItems(filtersToRender)}
         </ul>
       </div>
     );
@@ -65,6 +89,10 @@ BookFilters.propTypes = {
   filters: PropTypes.array,
   selectableFilters: PropTypes.array,
   setSelectedFilter: PropTypes.func,
+};
+
+BookFilters.defaultProps = {
+  filters: [],
 };
 
 export default BookFilters;

--- a/src/app/components/BookFilters/BookFilters.jsx
+++ b/src/app/components/BookFilters/BookFilters.jsx
@@ -1,30 +1,52 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FilterIcon } from 'dgx-svg-icons';
-
+import {
+  contains as _contains,
+  findWhere as _findWhere,
+} from 'underscore';
 import Filter from './Filter';
-import Actions from '../../actions/BookActions';
 
 class BookFilters extends React.Component {
   constructor(props) {
     super(props);
 
+    this.state = {
+      filters: this.props.filters.map(filter => ({
+        active: false,
+        id: filter.toLowerCase().split(' ').join('-'),
+        label: filter,
+      })),
+    };
+
     this.renderItems = this.renderItems.bind(this);
     this.onClick = this.onClick.bind(this);
   }
 
-  onClick(filterId, active) {
-    Actions.setSelectedFilter(filterId, active);
+  onClick(filter, active) {
+    const filterId = filter.toLowerCase().split(' ').join('-');
+    const f = _findWhere(this.state.filters, { id: filterId });
+    // This is still the filter object from the state:
+    f.active = active;
+    this.props.setSelectedFilter(filterId, active);
+
+    this.setState({ filters: this.state.filters });
   }
 
   renderItems(filters) {
-    return filters.map((filter, i) =>
+    const filtersToRender = this.props.selectableFilters.length ?
+      filters.filter(filter =>
+        _contains(this.props.selectableFilters, filter.id)
+      )
+      : filters;
+
+    return filtersToRender.map((filter, i) =>
       <Filter key={i} filter={filter} onClick={this.onClick} />
     );
   }
 
   render() {
-    const filters = this.props.filters;
+    const filters = this.state.filters;
 
     return (
       <div className="book-filters">
@@ -41,6 +63,8 @@ class BookFilters extends React.Component {
 
 BookFilters.propTypes = {
   filters: PropTypes.array,
+  selectableFilters: PropTypes.array,
+  setSelectedFilter: PropTypes.func,
 };
 
 export default BookFilters;

--- a/src/app/components/BookFilters/Filter.jsx
+++ b/src/app/components/BookFilters/Filter.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import {
   CheckSoloIcon,
@@ -10,42 +11,56 @@ class Filter extends React.Component {
     super(props);
 
     this.state = {
-      selected: false,
+      active: this.props.filter.active,
       buttonActive: false,
     };
     this.onClick = this.onClick.bind(this);
   }
 
+  componentWillReceiveProps(nextProps) {
+    // If the new props are active and it's already NOT active,
+    // then make it active but delay the SVG icon switch.
+    if (nextProps.filter.active && !this.state.active) {
+      this.setState({
+        buttonActive: true,
+        active: true,
+      });
+
+      setTimeout(() => {
+        this.setState({ buttonActive: false });
+      }, 500);
+    }
+  }
+
   onClick() {
-    const filterId = this.props.filter.toLowerCase().split(' ').join('-');
-    this.props.onClick(filterId, !this.state.selected);
-    this.setState({
-      selected: !this.state.selected,
-      buttonActive: true,
-    });
+    const filter = this.props.filter;
+    this.props.onClick(filter.label, !filter.active);
+    // Only set the state to false if it's already true.
+    // Only needed for the internal state of the animation SVG.
+    if (this.state.active) {
+      this.setState({ active: false });
+    }
 
     setTimeout(() => {
-      this.setState({ buttonActive: false });
-    }, 1000);
+      ReactDOM.findDOMNode(this.refs[this.props.filter.label]).focus();
+    }, 400);
   }
 
   render() {
-    const {
-      selected,
-      buttonActive,
-    } = this.state;
+    const { buttonActive } = this.state;
     const filter = this.props.filter;
-    const activeClass = selected ? 'active' : '';
+    const activeClass = filter.active ? 'active' : '';
     const iconType = buttonActive ? <DotsIcon /> : <CheckSoloIcon />;
 
     return (
       <li className="filter-item">
         <button
+          ref={filter.label}
           className={`nypl-primary-button ${activeClass}`}
           onClick={this.onClick}
         >
           {iconType}
-          {filter}
+          {filter.label}
         </button>
       </li>
     );
@@ -53,7 +68,7 @@ class Filter extends React.Component {
 }
 
 Filter.propTypes = {
-  filter: PropTypes.string,
+  filter: PropTypes.object,
   onClick: PropTypes.func,
 };
 

--- a/src/app/components/BookFilters/Filter.jsx
+++ b/src/app/components/BookFilters/Filter.jsx
@@ -36,9 +36,7 @@ class Filter extends React.Component {
     // then load the animation and remove it shortly after. Also focus on it whether it was
     // selected or deselected for accessibility.
     if (filter.id === focusId) {
-      this.setState({
-        loading: true,
-      });
+      this.setState({ loading: true });
 
       setTimeout(() => {
         this.setState({ loading: false });

--- a/src/app/components/BookList/BookList.jsx
+++ b/src/app/components/BookList/BookList.jsx
@@ -2,36 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Book from '../Book/Book.jsx';
-import utils from '../../utils/utils';
 
 const BookList = (props) => {
-  const currentPicks = props.currentMonthPicks;
-  const picks = currentPicks.picks ? currentPicks.picks : [];
-  const getFilteredBookItems = (pickItems, selectedFilters) => {
-    // Only execute filtering if the picks object is not empty
-    if (pickItems.length) {
-      // Only execute filtering if the selectedFilters object is not empty
-      if (selectedFilters.length) {
-        return pickItems.filter(book => {
-          // Get the pick's tags in an ID readable array
-          const tagArray = utils.getPickTags(book);
-          // Get the array of selected tags found in the book item
-          const inSelectedFilter = utils.getSelectedTags(tagArray, props.selectedFilters);
-
-          if (inSelectedFilter.length &&
-              (inSelectedFilter.length === props.selectedFilters.length)) {
-            return book;
-          }
-
-          return undefined;
-        });
-      }
-      // No filters, return original picks
-      return pickItems;
-    }
-    return pickItems;
-  };
-
   const renderBookItems = (currentBooks) => (
     currentBooks.length ? currentBooks.map((book, i) => <Book key={i} book={book} />) : null
   );
@@ -40,15 +12,19 @@ const BookList = (props) => {
     <div className="booklist nypl-column-three-quarters">
       <h2>2017 Picks</h2>
       <ul className="nypl-row">
-        {renderBookItems(getFilteredBookItems(picks, props.selectedFilters))}
+        {renderBookItems(props.picks)}
       </ul>
     </div>
   );
 };
 
 BookList.propTypes = {
-  currentMonthPicks: PropTypes.object,
+  picks: PropTypes.array,
   selectedFilters: PropTypes.array,
+};
+
+BookList.defaultProps = {
+  picks: [],
 };
 
 BookList.defaultProps = {

--- a/src/app/components/Sidebar/Sidebar.jsx
+++ b/src/app/components/Sidebar/Sidebar.jsx
@@ -12,7 +12,11 @@ const Sidebar = (props) => (
       Best Books for kids
     </a>
 
-    <BookFilters filters={props.filters} />
+    <BookFilters
+      filters={props.filters}
+      selectableFilters={props.selectableFilters}
+      setSelectedFilter={props.setSelectedFilter}
+    />
 
     <About />
   </div>
@@ -20,6 +24,8 @@ const Sidebar = (props) => (
 
 Sidebar.propTypes = {
   filters: PropTypes.array,
+  selectableFilters: PropTypes.array,
+  setSelectedFilter: PropTypes.func,
 };
 
 export default Sidebar;

--- a/src/app/stores/BookStore.js
+++ b/src/app/stores/BookStore.js
@@ -9,12 +9,14 @@ class BookStore {
       updatePicks: BookActions.UPDATE_PICKS,
       updateInitialFilters: BookActions.UPDATE_INITIAL_FILTERS,
       setSelectedFilter: BookActions.SET_SELECTED_FILTER,
+      setSelectableFilters: BookActions.SET_SELECTABLE_FILTERS,
     });
 
     this.state = {
       filters: [],
       currentMonthPicks: {},
       selectedFilters: [],
+      selectableFilters: [],
     };
   }
 
@@ -38,6 +40,10 @@ class BookStore {
     }
 
     this.setState({ selectedFilters: newFilters });
+  }
+
+  setSelectableFilters(selectableFilters) {
+    this.setState({ selectableFilters });
   }
 }
 

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -44,18 +44,19 @@ function Utils() {
    * @param {array} selectedFilters
    */
   this.getSelectedTags = (tagArray, selectedFilters) => {
-    const inSelectedFilter = [];
+    const selectedTags = [];
     _each(tagArray, (bookTag) => {
       if (_contains(selectedFilters, bookTag)) {
-        inSelectedFilter.push(bookTag);
+        selectedTags.push(bookTag);
       }
     });
 
-    return inSelectedFilter;
+    return selectedTags;
   };
 
   /**
    * getSelectableTags(picks)
+   * Get the subset of tags that can be selected based on the subset of picks.
    *
    * @param {array} picks
    */

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -53,6 +53,22 @@ function Utils() {
 
     return inSelectedFilter;
   };
+
+  /**
+   * getSelectableTags(picks)
+   *
+   * @param {array} picks
+   */
+  this.getSelectableTags = (picks) => {
+    let selectableFilters = [];
+
+    _each(picks, book => {
+      const tagArray = this.getPickTags(book);
+      selectableFilters = _union(selectableFilters, tagArray);
+    });
+
+    return selectableFilters;
+  };
 }
 
 export default new Utils();

--- a/src/server/routes/annualData.js
+++ b/src/server/routes/annualData.js
@@ -1,6 +1,8 @@
 import axios from 'axios';
+
 import appConfig from '../../../appConfig.js';
 import dataSet from '../../../test2017Data.js';
+import utils from '../../app/utils/utils';
 
 const {
   baseUrl,
@@ -12,6 +14,7 @@ const {
  */
 function annualCurrentData(type, req, res, next) {
   const endpoint = `${baseAnnualUrl}api`;
+  const selectableFilters = utils.getSelectableTags(dataSet.picks);
 
   res.locals.data = {
     BookStore: {
@@ -30,6 +33,7 @@ function annualCurrentData(type, req, res, next) {
         'Historical',
         'Middle grade',
         'Nature',
+        'Offbeat',
         'Picture books',
         'Poetry',
         'Science fiction',
@@ -39,6 +43,7 @@ function annualCurrentData(type, req, res, next) {
       ],
       currentMonthPicks: dataSet,
       selectedFilters: [],
+      selectableFilters,
     },
     endpoint,
   };

--- a/src/server/routes/annualData.js
+++ b/src/server/routes/annualData.js
@@ -14,6 +14,7 @@ const {
  */
 function annualCurrentData(type, req, res, next) {
   const endpoint = `${baseAnnualUrl}api`;
+  // Get the subset of tags that the picks can be filtered by.
   const selectableFilters = utils.getSelectableTags(dataSet.picks);
 
   res.locals.data = {


### PR DESCRIPTION
Fixes #26 Big PR:

* Removes re-useable functions and puts them in `utils`.
* Removes Action calls and instead triggers function calls up to the parent `Main` component.
* This is useful to keep track of both the filtered book item array and the filtered filter array.
* Clicking on a filter updates the SVG and also triggers the focus on them AFTER they get rendered since we want to keep track of what was selected/deselected for a11y purposes.