### PR TITLE
updated package.json and source to remove unused packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,6 @@
-// require('newrelic');
-
 /** IMPORTANT **/
 // Babel/Register allows us to import ES6 and JSX React Components in Node.
 // Without this step, the Component assignment would fail.
 // Similary, we use Webpack Babel to transpile our ES6 codebase into ES5.
 require('babel-register');
-
 require('./server.js');

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dgx-staff-picks",
+  "name": "staff-picks",
   "version": "2.5.0",
   "description": "NYPL Staff Picks",
   "main": "index.js",
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/NYPL/Staff-Picks"
+    "url": "https://github.com/NYPL/staff-picks"
   },
   "keywords": [
     "react",
@@ -27,10 +27,10 @@
     "hot",
     "reload"
   ],
-  "author": "NYPL Digital Experience",
+  "author": "NYPL Digital",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/NYPL/Staff-Picks/issues"
+    "url": "https://github.com/NYPL/staff-picks/issues"
   },
   "dependencies": {
     "@nypl/design-toolkit": "0.1.27",
@@ -56,8 +56,6 @@
     "extract-text-webpack-plugin": "1.0.1",
     "history": "1.15.0",
     "iso": "5.2.0",
-    "jsonapi-parserinator": "0.5.0",
-    "newrelic": "1.21.1",
     "node-sass": "3.8.0",
     "prop-types": "15.5.10",
     "react": "15.5.4",
@@ -75,7 +73,6 @@
   "devDependencies": {
     "axios-mock-adapter": "1.7.1",
     "chai": "3.5.0",
-    "create-react-class": "15.5.3",
     "enzyme": "2.9.1",
     "eslint": "4.9.0",
     "eslint-config-airbnb": "16.1.0",


### PR DESCRIPTION
This small PR focuses on removing NPM packages we currently don't need. As needs arise, we should first think about really adding more dependencies and then add to the appropriate section (`devDependencies` vs `dependencies`)

Ideally I would like to setup AWS to run `npm install --production` to improve the install process on deployments.

Fixes #38 

CC: @kfriedman @EdwinGuzman 