### PR TITLE
Updating the left sidebar 'back' link to be a nav.

### DIFF
--- a/src/app/components/Sidebar/Sidebar.jsx
+++ b/src/app/components/Sidebar/Sidebar.jsx
@@ -7,9 +7,11 @@ import config from '../../../../appConfig';
 
 const Sidebar = (props) => (
   <div className="sidebar nypl-column-one-quarter">
-    <a href={config.recommendationsLink.url} className="back-link">
-      <LeftWedgeIcon /> {config.recommendationsLink.label}
-    </a>
+    <nav aria-label="Breadcrumbs">
+      <a href={config.recommendationsLink.url} className="back-link">
+        <LeftWedgeIcon title="Return to" ariaHidden={false} /> {config.recommendationsLink.label}
+      </a>
+    </nav>
 
     <BookFilters
       filters={props.filters}

--- a/test/unit/Sidebar.test.js
+++ b/test/unit/Sidebar.test.js
@@ -25,7 +25,7 @@ describe('Sidebar', () => {
       const breadcrumbLink = component.find('a').at(0);
       expect(breadcrumbLink).to.have.length(1);
       // The first part of the "text" is the hidden SVG title which is not hidden in the tests.
-      expect(breadcrumbLink.text()).to.equal('NYPL Left Wedge SVG Icon Recommendations');
+      expect(breadcrumbLink.text()).to.equal('Return to Recommendations');
       expect(breadcrumbLink.prop('href'))
         .to.equal('https://www.nypl.org/books-music-dvds/recommendations');
     });


### PR DESCRIPTION
Fixes #64 

* The SVG icon now reads "Return to"
* The link is surrounded in a `<nav>` element.

![screen shot 2017-10-31 at 3 34 42 pm](https://user-images.githubusercontent.com/1280564/32245154-3cfeaa76-be51-11e7-821d-093ddf386f6f.png)
