### PR TITLE
Updating the page's title based on the route.

### DIFF
--- a/appConfig.js
+++ b/appConfig.js
@@ -60,6 +60,10 @@ const config = {
       },
     },
   },
+  pageTitle: {
+    ya: 'Best Books for Teens',
+    childrens: 'Best Books for Kids',
+  },
 };
 
 export default config;

--- a/server.js
+++ b/server.js
@@ -86,6 +86,7 @@ app.use('/', (req, res) => {
           appEnv: process.env.APP_ENV || 'no APP_ENV',
           assets: buildAssets,
           webpackPort: WEBPACK_DEV_PORT,
+          pageTitle: res.locals.data.pageTitle,
         });
     } else {
       res.status(404).send('Not found');

--- a/src/server/routes/annualData.js
+++ b/src/server/routes/annualData.js
@@ -12,8 +12,16 @@ const nyplApiClientGet = (endpoint) =>
  * Get the latest annual staff pick list for either childrens or ya.
  */
 function annualCurrentData(type, req, res, next) {
-  // Hard coded endpoint for now
-  nyplApiClientGet(`/book-lists/${type}/2017`)
+  const pageTitle = appConfig.pageTitle[type];
+  let dataType = '';
+
+  if (type === 'childrens') {
+    dataType = 'kids';
+  } else if (type === 'ya') {
+    dataType = 'teens';
+  }
+
+  nyplApiClientGet(`/book-lists/${dataType}/2017`)
     .then(data => {
       const filters = utils.getAllTags(data.picks);
       // Get the subset of tags that the picks can be filtered by.
@@ -26,6 +34,7 @@ function annualCurrentData(type, req, res, next) {
           selectableFilters,
           isJsEnabled: false,
         },
+        pageTitle,
       };
 
       next();
@@ -41,12 +50,8 @@ function annualCurrentData(type, req, res, next) {
 function selectAnnualData(req, res, next) {
   const type = req.params.type;
 
-  if (type === 'childrens') {
-    return annualCurrentData('kids', req, res, next);
-  }
-
-  if (type === 'ya') {
-    return annualCurrentData('teens', req, res, next);
+  if (type === 'childrens' || type === 'ya') {
+    return annualCurrentData(type, req, res, next);
   }
 
   return res.redirect(baseUrl);

--- a/src/server/views/index.ejs
+++ b/src/server/views/index.ejs
@@ -1,6 +1,6 @@
 <html lang="en">
   <head>
-    <title>NYPL | Recommendations</title>
+    <title><%= pageTitle %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <% for (var i=0; i < metatags.length; i++) {%>


### PR DESCRIPTION
Fixes #67 

The page's title should now read either "Best Books for Teens" or "Best Books for Kids".