### PR TITLE
Hero accessibility

### DIFF
--- a/appConfig.js
+++ b/appConfig.js
@@ -45,15 +45,15 @@ const config = {
   heroData: {
     annual: {
       ya: {
-        category: 'Recommends',
+        category: '',
         header: 'Best Books for Teens',
         description: 'Explore our annual selection of outstanding young adult titles.',
         heroImageUrl: 'http://staff-picks-dev.us-east-1.elasticbeanstalk.com/books-music-dvds/' +
           'recommendations/staff-picks/src/client/images/desktop.banner.YA.FIN.png',
       },
       childrens: {
-        category: 'Recommends',
-        header: 'Best Books for Children',
+        category: '',
+        header: 'Best Books for Kids',
         description: 'Explore our annual selection of outstanding childrens titles.',
         heroImageUrl: 'http://staff-picks-dev.us-east-1.elasticbeanstalk.com/books-music-dvds/' +
           'recommendations/staff-picks/src/client/images/desktop.childrens100.FIN.png',

--- a/src/app/components/Hero/Hero.jsx
+++ b/src/app/components/Hero/Hero.jsx
@@ -16,10 +16,9 @@ class Hero extends React.Component {
         <div className="Hero__container nypl-full-width-wrapper">
           <div className="Hero__text nypl-column-three-quarters nypl-column-offset-one">
             <div className="Hero__text__HeroTitle">
-              <h3>{this.props.heroData.category}</h3>
-              <p className="Hero__text__HeroTitle__des">
+              <h1 className="Hero__text__HeroTitle__des">
                 {this.props.heroData.header}
-              </p>
+              </h1>
               <p className="Hero__text__HeroTitle__intro">
                 {this.props.heroData.description}
               </p>

--- a/src/app/components/Hero/Hero.jsx
+++ b/src/app/components/Hero/Hero.jsx
@@ -16,6 +16,7 @@ class Hero extends React.Component {
         <div className="Hero__container nypl-full-width-wrapper">
           <div className="Hero__text nypl-column-three-quarters nypl-column-offset-one">
             <div className="Hero__text__HeroTitle">
+              {this.props.heroData.category ? <p>{this.props.heroData.category}</p> : ''}
               <h1 className="Hero__text__HeroTitle__des">
                 {this.props.heroData.header}
               </h1>


### PR DESCRIPTION
This PR addresses #59 and #60. It:

- Removes the "category" heading
- Changes the main header to a `h1`.
- Updates the main header copy 