### PR TITLE
Added illustrator and/or translator if they exist. Updated styles and…

### DIFF
--- a/src/app/components/Book/Book.jsx
+++ b/src/app/components/Book/Book.jsx
@@ -33,6 +33,15 @@ const Book = ({ pick }) => {
     !isStringEmpty(author) ? <p className="book-item-author">{author}</p> : null
   );
 
+  const renderIllustrator = (illustrator) => (
+    !isStringEmpty(illustrator) ? <p className="book-item-illustrator">Illustrated By: {illustrator}</p> : null
+  );
+
+  const renderTranslator= (translator) => (
+    !isStringEmpty(translator) ? <p className="book-item-translator">Translated By: {translator}</p> : null
+  );
+
+
   const renderCatalogLinks = (catalogUrl, ebookUrl) => {
     const catalogLink = !isStringEmpty(catalogUrl) ?
       <a href={catalogUrl} className="catalog-url">
@@ -68,15 +77,19 @@ const Book = ({ pick }) => {
   const book = getBookObject(pick);
   const reviewsArray = getReviewsArray(pick);
   const tagsArray = utils.getPickTags(pick);
+  const hasIllustratorTranslatorClass = !isStringEmpty(book.translator)
+    && !isStringEmpty(book.illustrator) ? 'withTranslatorIllustrator' : '';
 
   return (
     <li
-      className={`book-item ${getTagClasses(tagsArray)}`}
+      className={`book-item ${getTagClasses(tagsArray)} ${hasIllustratorTranslatorClass}`}
       key={!isStringEmpty(book.title) ? book.title : null}
     >
       {renderBookCoverImage(book.imageUrl)}
       {renderTitle(book.title)}
       {renderAuthor(book.author)}
+      {renderIllustrator(book.illustrator)}
+      {renderTranslator(book.translator)}
       {renderCatalogLinks(book.catalogUrl, book.ebookUrl)}
       {renderDescription(reviewsArray)}
     </li>

--- a/src/app/components/Book/Book.jsx
+++ b/src/app/components/Book/Book.jsx
@@ -34,13 +34,14 @@ const Book = ({ pick }) => {
   );
 
   const renderIllustrator = (illustrator) => (
-    !isStringEmpty(illustrator) ? <p className="book-item-illustrator">Illustrated By: {illustrator}</p> : null
+    !isStringEmpty(illustrator) ?
+      <p className="book-item-illustrator">Illustrated by {illustrator}</p> : null
   );
 
-  const renderTranslator= (translator) => (
-    !isStringEmpty(translator) ? <p className="book-item-translator">Translated By: {translator}</p> : null
+  const renderTranslator = (translator) => (
+    !isStringEmpty(translator) ?
+      <p className="book-item-translator">Translated by {translator}</p> : null
   );
-
 
   const renderCatalogLinks = (catalogUrl, ebookUrl) => {
     const catalogLink = !isStringEmpty(catalogUrl) ?

--- a/src/client/styles/components/_bookItem.scss
+++ b/src/client/styles/components/_bookItem.scss
@@ -1,3 +1,6 @@
+$book-card-smallscreen-gutter: 2.5%;
+$book-card-largescreen-gutter: 3.5%;
+
 .book-item {
   border-bottom: 2px solid $nypl-gray-cool;
   margin: .5em .25em 1.5em .25em;
@@ -5,6 +8,12 @@
   padding-top: .75em;
   max-width: 100%;
   @include clearfix;
+
+  &.withTranslatorIllustrator {
+    .book-item-illustrator {
+      margin-bottom: 0;
+    }
+  }
 
   // Split into two columns
   @include min-screen($mobile-breakpoint) {
@@ -31,33 +40,65 @@
     float: left;
 
     @include min-screen($xtrasmall-breakpoint) {
+      min-height: 280px;
+    }
+
+    @include min-screen($xtrasmall-breakpoint + 150px) {
       min-height: 400px;
     }
 
     img {
       display: block;
       max-width: 100%;
-      margin: 0 2.5%;
+      margin: 0 $book-card-smallscreen-gutter;
     }
   }
 
   &-title {
     float: left;
     font-weight: bold;
-    margin: 0 2.5%;
+    margin: 0 $book-card-smallscreen-gutter;
     width: 65%;
+    line-height: 1.2;
+
+    @include min-screen($mobile-breakpoint) {
+      margin: 0 $book-card-largescreen-gutter;
+      width: 63%;
+    }
   }
 
   &-author {
     float: left;
     font-size: 1.05rem;
     font-weight: normal;
-    margin: 7.5% 2.5%;
+    margin: 3% $book-card-smallscreen-gutter 0;
     width: 65%;
 
-    @include min-screen($xtrasmall-breakpoint) {
-      margin-bottom: 3.5%;
-      margin-top: 3.5%;
+    @include min-screen($mobile-breakpoint) {
+      margin: 3% $book-card-largescreen-gutter 0;
+      width: 63%;
+    }
+  }
+
+  &-illustrator {
+    float: left;
+    width: 65%;
+    margin: 0 $book-card-smallscreen-gutter 1.25%;
+
+    @include min-screen($mobile-breakpoint) {
+      margin: 0 $book-card-largescreen-gutter 1.25%;
+      width: 63%;
+    }
+  }
+
+  &-translator {
+    float: left;
+    width: 65%;
+    margin: 0 $book-card-smallscreen-gutter 1.25%;
+
+    @include min-screen($mobile-breakpoint) {
+      margin: 0 $book-card-largescreen-gutter 1.25%;
+      width: 63%;
     }
   }
 
@@ -68,9 +109,14 @@
     @include min-screen($xtrasmall-breakpoint) {
       clear: none;
       float: left;
-      margin: 0 2.5%;
+      margin: 0 $book-card-smallscreen-gutter;
       padding: 0;
       width: 65%;
+    }
+
+    @include min-screen($mobile-breakpoint) {
+      width: 63%;
+      margin: 0 $book-card-largescreen-gutter;
     }
 
     a {
@@ -90,7 +136,7 @@
 
       &:first-child {
         @include min-screen($xtrasmall-breakpoint) {
-          margin: 0 10px 10px 0;
+          margin: 10px 10px 10px 0;
         }
       }
 
@@ -140,7 +186,12 @@
       clear: none;
       float: left;
       width: 65%;
-      margin: 1% 2.5%
+      margin: 1% $book-card-smallscreen-gutter;
+    }
+
+    @include min-screen($mobile-breakpoint) {
+      margin: 1% $book-card-largescreen-gutter;
+      width: 63%;
     }
   }
 }

--- a/test/unit/Book.test.js
+++ b/test/unit/Book.test.js
@@ -111,14 +111,14 @@ describe('Book Component', () => {
       const text = component.find('.book-item-translator');
       expect(text.length).to.equal(1);
       expect(text.find('p').length).to.equal(1);
-      expect(text.find('p').text()).to.equal('Translated By: ' + pickObject.book.translator);
+      expect(text.find('p').text()).to.equal('Translated by ' + pickObject.book.translator);
     });
 
     it('should render the pick illustrator <p> element with text', () => {
       const text = component.find('.book-item-illustrator');
       expect(text.length).to.equal(1);
       expect(text.find('p').length).to.equal(1);
-      expect(text.find('p').text()).to.equal('Illustrated By: ' + pickObject.book.illustrator);
+      expect(text.find('p').text()).to.equal('Illustrated by ' + pickObject.book.illustrator);
     });
 
     it('should assign a .withTranslatorIllustrator class if both translator and illustrator exist', () => {

--- a/test/unit/Book.test.js
+++ b/test/unit/Book.test.js
@@ -27,7 +27,9 @@ const pickObject = {
     "imageUrl": "http://imagesb.btol.com/ContentCafe/Jacket.aspx?UserID=ContentCafeClient&Password=Client&Return=T&Type=L&Value=9780385539906",
     "isbn": "9780385539913",
     "overdriveId": "2678726",
-    "title": "A Gambler's Anatomy"
+    "title": "A Gambler's Anatomy",
+    "illustrator": "I am an illustrator",
+    "translator": "I am a translator"
   }
 };
 
@@ -103,6 +105,25 @@ describe('Book Component', () => {
       expect(linksWrapper.find('.ebook-url').length).to.equal(1);
       expect(linksWrapper.find('.ebook-url').text()).to.contain('Request E-Book');
       expect(linksWrapper.find('.ebook-url').prop('href')).to.equal(pickObject.book.ebookUrl);
+    });
+
+    it('should render the pick translator <p> element with text', () => {
+      const text = component.find('.book-item-translator');
+      expect(text.length).to.equal(1);
+      expect(text.find('p').length).to.equal(1);
+      expect(text.find('p').text()).to.equal('Translated By: ' + pickObject.book.translator);
+    });
+
+    it('should render the pick illustrator <p> element with text', () => {
+      const text = component.find('.book-item-illustrator');
+      expect(text.length).to.equal(1);
+      expect(text.find('p').length).to.equal(1);
+      expect(text.find('p').text()).to.equal('Illustrated By: ' + pickObject.book.illustrator);
+    });
+
+    it('should assign a .withTranslatorIllustrator class if both translator and illustrator exist', () => {
+      const bookWrapper = component.find('.book-item');
+      expect(bookWrapper.hasClass('withTranslatorIllustrator')).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
Fixes #91 and #79 

- Updated Book component to render `Illustrator` and `Translator` properties if defined
- Updated Book unit test to account for this change
- Modified styles to address #79 with @ricardoom 
- Modified styles to space out `illustrator` and `translator` <p> tags when rendered
- Updated breakpoint for gap fixing with @ricardoom 

All this is up on AWS DEV
- http://staff-picks-dev.us-east-1.elasticbeanstalk.com/books-music-dvds/recommendations/best-books/ya
- http://staff-picks-dev.us-east-1.elasticbeanstalk.com/books-music-dvds/recommendations/best-books/childrens