### PR TITLE
Api kms client

### DIFF
--- a/src/server/helper/kmsClientHelper.js
+++ b/src/server/helper/kmsClientHelper.js
@@ -47,27 +47,22 @@ const kmsClientHelper = (options) => {
     // If we want to use encrypted client id and secret strings, then we first need to
     // decrypt the strings and instantiate the NyplDataApiClient with those decrypted values.
     if (kmsEnvironment === 'encrypted') {
-      return new Promise((resolve, reject) => {
-        Promise.all(keys.map(decryptKMS))
-          .then(([decryptedClientId, decryptedClientSecret]) => {
-            const nyplApiClient = new NyplDataApiClient({
-              base_url: apiBase,
-              oauth_key: decryptedClientId,
-              oauth_secret: decryptedClientSecret,
-              oauth_url: tokenUrl,
-            });
-
-            CACHE.clientId = decryptedClientId;
-            CACHE.clientSecret = decryptedClientSecret;
-            CACHE.nyplApiClient = nyplApiClient;
-
-            resolve(nyplApiClient);
-          })
-          .catch(error => {
-            console.log('ERROR trying to decrypt using KMS.', error);
-            reject('ERROR trying to decrypt using KMS.', error);
+      return Promise.all(keys.map(decryptKMS))
+        .then(([decryptedClientId, decryptedClientSecret]) => {
+          const nyplApiClient = new NyplDataApiClient({
+            base_url: apiBase,
+            oauth_key: decryptedClientId,
+            oauth_secret: decryptedClientSecret,
+            oauth_url: tokenUrl,
           });
-      });
+
+          CACHE.nyplApiClient = nyplApiClient;
+
+          return nyplApiClient;
+        })
+        .catch(error => {
+          throw ('ERROR trying to decrypt using KMS.', error);
+        });
     }
 
     // If we are using unencrypted strings, then simply use those.
@@ -78,8 +73,6 @@ const kmsClientHelper = (options) => {
       oauth_url: tokenUrl,
     });
 
-    CACHE.clientId = clientId;
-    CACHE.clientSecret = clientSecret;
     CACHE.nyplApiClient = nyplApiClient;
 
     return Promise.resolve(nyplApiClient);

--- a/src/server/helper/nyplApiClient.js
+++ b/src/server/helper/nyplApiClient.js
@@ -1,83 +1,9 @@
-import NyplApiClient from '@nypl/nypl-data-api-client';
-import aws from 'aws-sdk';
-
 import config from '../../../appConfig.js';
+
+import kmsClientHelper from './nyplApiClientHelper';
 
 const appEnvironment = process.env.APP_ENV || 'production';
 const kmsEnvironment = process.env.KMS_ENV || 'encrypted';
 const apiBase = config.api[appEnvironment];
-let decryptKMS;
-let kms;
 
-if (kmsEnvironment === 'encrypted') {
-  kms = new aws.KMS({
-    region: 'us-east-1',
-  });
-
-  decryptKMS = (key) => {
-    const params = {
-      CiphertextBlob: new Buffer(key, 'base64'),
-    };
-
-    return new Promise((resolve, reject) => {
-      kms.decrypt(params, (err, data) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(data.Plaintext.toString());
-        }
-      });
-    });
-  };
-}
-
-const clientId = process.env.clientId;
-const clientSecret = process.env.clientSecret;
-
-const keys = [clientId, clientSecret];
-const CACHE = {};
-
-function client() {
-  if (CACHE.nyplApiClient) {
-    return Promise.resolve(CACHE.nyplApiClient);
-  }
-
-  if (kmsEnvironment === 'encrypted') {
-    return new Promise((resolve, reject) => {
-      Promise.all(keys.map(decryptKMS))
-        .then(([decryptedClientId, decryptedClientSecret]) => {
-          const nyplApiClient = new NyplApiClient({
-            base_url: apiBase,
-            oauth_key: decryptedClientId,
-            oauth_secret: decryptedClientSecret,
-            oauth_url: config.tokenUrl,
-          });
-
-          CACHE.clientId = decryptedClientId;
-          CACHE.clientSecret = decryptedClientSecret;
-          CACHE.nyplApiClient = nyplApiClient;
-
-          resolve(nyplApiClient);
-        })
-        .catch(error => {
-          console.log('ERROR trying to decrypt using KMS.', error);
-          reject('ERROR trying to decrypt using KMS.', error);
-        });
-    });
-  }
-
-  const nyplApiClient = new NyplApiClient({
-    base_url: apiBase,
-    oauth_key: clientId,
-    oauth_secret: clientSecret,
-    oauth_url: config.tokenUrl,
-  });
-
-  CACHE.clientId = clientId;
-  CACHE.clientSecret = clientSecret;
-  CACHE.nyplApiClient = nyplApiClient;
-
-  return Promise.resolve(nyplApiClient);
-}
-
-export default client;
+export default kmsClientHelper(appEnvironment, kmsEnvironment, apiBase, config.tokenUrl);

--- a/src/server/helper/nyplApiClient.js
+++ b/src/server/helper/nyplApiClient.js
@@ -1,9 +1,14 @@
 import config from '../../../appConfig.js';
 
-import kmsClientHelper from './nyplApiClientHelper';
+import kmsClientHelper from './kmsClientHelper';
 
 const appEnvironment = process.env.APP_ENV || 'production';
-const kmsEnvironment = process.env.KMS_ENV || 'encrypted';
-const apiBase = config.api[appEnvironment];
+const options = {
+  kmsEnvironment: process.env.KMS_ENV || 'encrypted',
+  clientId: process.env.clientId || '',
+  clientSecret: process.env.clientSecret || '',
+  apiBase: config.api[appEnvironment],
+  tokenUrl: config.tokenUrl,
+};
 
-export default kmsClientHelper(appEnvironment, kmsEnvironment, apiBase, config.tokenUrl);
+export default kmsClientHelper(options);

--- a/src/server/helper/nyplApiClientHelper.js
+++ b/src/server/helper/nyplApiClientHelper.js
@@ -1,0 +1,82 @@
+import NyplApiClient from '@nypl/nypl-data-api-client';
+import aws from 'aws-sdk';
+
+const kmsClientHelper = (appEnvironment, kmsEnvironment, apiBase, tokenUrl) => {
+  let decryptKMS;
+  let kms;
+
+  if (kmsEnvironment === 'encrypted') {
+    kms = new aws.KMS({
+      region: 'us-east-1',
+    });
+
+    decryptKMS = (key) => {
+      const params = {
+        CiphertextBlob: new Buffer(key, 'base64'),
+      };
+
+      return new Promise((resolve, reject) => {
+        kms.decrypt(params, (err, data) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(data.Plaintext.toString());
+          }
+        });
+      });
+    };
+  }
+
+  const clientId = process.env.clientId;
+  const clientSecret = process.env.clientSecret;
+
+  const keys = [clientId, clientSecret];
+  const CACHE = {};
+
+  function client() {
+    if (CACHE.nyplApiClient) {
+      return Promise.resolve(CACHE.nyplApiClient);
+    }
+
+    if (kmsEnvironment === 'encrypted') {
+      return new Promise((resolve, reject) => {
+        Promise.all(keys.map(decryptKMS))
+          .then(([decryptedClientId, decryptedClientSecret]) => {
+            const nyplApiClient = new NyplApiClient({
+              base_url: apiBase,
+              oauth_key: decryptedClientId,
+              oauth_secret: decryptedClientSecret,
+              oauth_url: tokenUrl,
+            });
+
+            CACHE.clientId = decryptedClientId;
+            CACHE.clientSecret = decryptedClientSecret;
+            CACHE.nyplApiClient = nyplApiClient;
+
+            resolve(nyplApiClient);
+          })
+          .catch(error => {
+            console.log('ERROR trying to decrypt using KMS.', error);
+            reject('ERROR trying to decrypt using KMS.', error);
+          });
+      });
+    }
+
+    const nyplApiClient = new NyplApiClient({
+      base_url: apiBase,
+      oauth_key: clientId,
+      oauth_secret: clientSecret,
+      oauth_url: tokenUrl,
+    });
+
+    CACHE.clientId = clientId;
+    CACHE.clientSecret = clientSecret;
+    CACHE.nyplApiClient = nyplApiClient;
+
+    return Promise.resolve(nyplApiClient);
+  }
+
+  return client;
+};
+
+export default kmsClientHelper;


### PR DESCRIPTION
Please check out the `kmsClientHelper.js` file. The ultimate goal is to make that file into a separate npm package.

Why? Because this same process is being used in Staff Picks and in Discovery.

Context:
We are using the [@nypl/nypl-data-api-client](https://www.npmjs.com/package/@nypl/nypl-data-api-client) and passing in each app's own client id and client secret (and oauth url) in order to make requests to the API.

The only issue is that we want to use encrypted versions of the client id and client secret as environment variables in AWS Elastic Beanstalk. In order to encrypt and decrypt, we are using AWS's KMS feature.

In AWS EB:
- Each app reads the encrypted environment variables,
- KMS decrypts the strings and instantiates the `nyplDataApiClient`,
- That client is stored and used to make requests

Locally:
- It's fine if we **don't** use encrypted environment variables. This also makes the start command that much shorter and easier in terminal,
- AWS KMS is **not** used so it's not instantiated,
- The `nyplDataApiClient` is used as before

I will write better comments and a better readme if this PR goes through in the npm package. Let me know what you think.
