### PR TITLE
Toggable filters

### DIFF
--- a/src/app/components/BookFilters/BookFilters.jsx
+++ b/src/app/components/BookFilters/BookFilters.jsx
@@ -108,8 +108,6 @@ class BookFilters extends React.Component {
     const booksfound = `${picksCount} book${picksCount === 1 ? '' : 's'} found`;
     const buttonAnimationClasses = showFilters ? 'rotate-up' : 'rotate-down';
     const filtersContainerDisplayClass = showFilters ? 'expand' : 'collapse';
-    // const bookListDisplayStyles = showFilters ?
-    //   { display: 'block', visibility: 'visible' } : { display: 'none', visibility: 'hidden' };
 
     return (
       <div className="book-filters">

--- a/src/app/components/BookFilters/BookFilters.jsx
+++ b/src/app/components/BookFilters/BookFilters.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {
   FilterIcon,
   ResetIcon,
+  LeftWedgeIcon,
 } from '@nypl/dgx-svg-icons';
 import { contains as _contains } from 'underscore';
 
@@ -20,10 +21,12 @@ class BookFilters extends React.Component {
       })),
       selectedFilters: this.props.selectedFilters,
       focusId: '',
+      showFilters: false,
     };
 
     this.renderItems = this.renderItems.bind(this);
     this.onClick = this.onClick.bind(this);
+    this.toggleFilters = this.toggleFilters.bind(this);
     this.getFilterArray = this.getFilterArray.bind(this);
   }
 
@@ -38,6 +41,10 @@ class BookFilters extends React.Component {
       filters: this.state.filters,
       focusId: filterId,
     });
+  }
+
+  toggleFilters() {
+    this.setState({ showFilters: !this.state.showFilters });
   }
 
   /**
@@ -76,7 +83,7 @@ class BookFilters extends React.Component {
   }
 
   render() {
-    const { filters } = this.state;
+    const { filters, showFilters } = this.state;
     const {
       selectableFilters,
       picksCount,
@@ -87,16 +94,29 @@ class BookFilters extends React.Component {
     }
 
     const filtersToRender = this.getFilterArray(selectableFilters, filters);
+    const toggleFiltersDisplayClass = showFilters ? 'expand' : 'collapse';
+    const buttonAnimationClasses = showFilters ? 'rotate-up' : 'rotate-down';
 
     return (
       <div className="book-filters">
         <div className="book-filters-heading">
-          <h2><FilterIcon /> Filter by Tags</h2>
+          <h2>
+            <FilterIcon ariaHidden />
+            <span>Filter by Tags</span>
+          </h2>
           <span aria-live="assertive" aria-atomic="true">
             {picksCount} book{picksCount === 1 ? '' : 's'} found
           </span>
+          <button
+            aria-expanded={showFilters}
+            onClick={this.toggleFilters}
+            className="book-filters-toggleButton"
+          >
+            <LeftWedgeIcon ariaHidden className={buttonAnimationClasses} />
+            <span className="visuallyHidden">{showFilters ? 'Collapse' : 'Expand'}</span>
+          </button>
         </div>
-        <ul>
+        <ul className={`book-filters-list ${toggleFiltersDisplayClass}`}>
           {this.renderItems(filtersToRender)}
         </ul>
         {

--- a/src/client/styles/components/_bookFilters.scss
+++ b/src/client/styles/components/_bookFilters.scss
@@ -1,5 +1,6 @@
 .book-filters {
   &-heading {
+    position: relative;
     border-top: 4px solid $nypl-red;
 
     h2 {
@@ -17,15 +18,56 @@
       }
     }
 
-    span {
+    & > span {
       font-size: 0.8rem;
-      margin: 0 0 0 15px;
+      margin: 0 0 0 12px;
       display: inline-block;
     }
   }
 
-  ul {
+  &-toggleButton {
+    -webkit-appearance: none;
+    background-color: $nypl-white;
+    border: none;
+    position: absolute;
+    right: .2em;
+    top: .4em;
+
+    @include min-screen($mobile-breakpoint) {
+      display: none;
+      visibility: hidden;
+    }
+
+    & .svgIcon {
+      @include transition-list(200ms linear);
+
+      &.rotate-up {
+        @include transform(rotate(90deg));
+      }
+      &.rotate-down {
+        @include transform(rotate(270deg));
+      }
+    }
+  }
+
+  &-list {
+    @include transition-list(max-height .3s ease-in-out);
     margin-left: 40px;
+    height: auto;
+    overflow: hidden;
+
+    // Accordion rules
+    &.collapse {
+      max-height: 0;
+
+      @include min-screen($mobile-breakpoint) {
+        max-height: none;
+      }
+    }
+
+    &.expand {
+      max-height: 50em;
+    }
   }
 
   .clear-button {

--- a/src/client/styles/utils/_mixins.scss
+++ b/src/client/styles/utils/_mixins.scss
@@ -115,19 +115,13 @@
   -moz-transform:    $params;
   transform:         $params;
 }
+
 @mixin transform-origin($params) {
   -webkit-transform-origin: $params;
   -moz-transform-origin:    $params;
   transform-origin:         $params;
 }
 
-// @mixin transition($params) {
-//   -moz-transition:    $params;
-//   -o-transition:      $params;
-//   -webkit-transition: $params;
-//   -ms-transition:     $params;
-//   transition:         $params;
-// }
 @mixin transition-list($values...){
   -moz-transition:    $values;
   -o-transition:      $values;
@@ -135,6 +129,7 @@
   -ms-transition:     $values;
   transition:         $values;
 }
+
 @mixin transition-transform($values...) {
   -webkit-transition: -webkit-transform $values;
      -moz-transition: -moz-transform $values;


### PR DESCRIPTION
Fixes #36 

Assigns proper `aria-expanded` attribute to collapsible state.
Uses class based declarations to expand/collapse
Updates to styles for filter buttons, clear button and overall grid container

PS: I need to write tests, which I hope it can be another ticket... @EdwinGuzman -- if you are fine with that then I can create an issue for next Sprint (else I will add tests to this PR)