### PR TITLE
Removing aria-labelledby and using aria-label for the filter list.

### DIFF
--- a/src/app/components/BookFilters/BookFilters.jsx
+++ b/src/app/components/BookFilters/BookFilters.jsx
@@ -139,10 +139,7 @@ class BookFilters extends React.Component {
           </button>
         </div>
         <div className={`book-filters-list ${filtersContainerDisplayClass}`}>
-          <span className="visuallyHidden" id="filter-list-description">
-            Click to apply or remove tags.
-          </span>
-          <ul aria-labelledby="filter-list-description">
+          <ul aria-label="Click to apply or remove tags.">
             {this.renderItems(filtersToRender)}
           </ul>
           {


### PR DESCRIPTION
Fixes #115 

I removed the span and used the `aria-label` in the `ul` itself. Another option that @wlla suggested was using the h2 'Filter by Tags' label as the label for the `ul`. Which do you think is better, @courtneymcgee ?

This is up on prod: http://staff-picks-production.us-east-1.elasticbeanstalk.com/books-music-dvds/recommendations/best-books/ya