### PR TITLE
Removing max-height.

### DIFF
--- a/src/client/styles/components/_bookFilters.scss
+++ b/src/client/styles/components/_bookFilters.scss
@@ -91,7 +91,6 @@
     }
 
     &.expand {
-      max-height: 50em;
       visibility: visible;
     }
 

--- a/src/client/styles/components/_bookFilters.scss
+++ b/src/client/styles/components/_bookFilters.scss
@@ -91,6 +91,7 @@
     }
 
     &.expand {
+      max-height: 100em;
       visibility: visible;
     }
 


### PR DESCRIPTION
@chrismulholland brought this up. If you set a max-height, not all the filters will show. This is an issue on mobile [childrens](http://staff-picks-dev.us-east-1.elasticbeanstalk.com/books-music-dvds/recommendations/best-books/childrens) but not [ya](http://staff-picks-dev.us-east-1.elasticbeanstalk.com/books-music-dvds/recommendations/best-books/ya).