### PR TITLE
Adding aria-label to book request links to read out the full item's title

### DIFF
--- a/src/app/components/Book/Book.jsx
+++ b/src/app/components/Book/Book.jsx
@@ -56,13 +56,23 @@ const Book = ({ pick, isJsEnabled }) => {
 
   const renderCatalogLinks = (catalogUrl, ebookUrl) => {
     const catalogLink = !isStringEmpty(catalogUrl) ?
-      <a href={catalogUrl} className="catalog-url" onClick={() => gaEvent('Book')}>
+      <a
+        href={catalogUrl}
+        className="catalog-url"
+        onClick={() => gaEvent('Book')}
+        aria-label={`Request Book: ${book.title}`}
+      >
         <BookIcon width="32px" height="32px" ariaHidden />
         <span>{config.requestUrlsText.catalog}</span>
       </a> : null;
 
     const ebookLink = !isStringEmpty(ebookUrl) ?
-      <a href={ebookUrl} className="ebook-url" onClick={() => gaEvent('E-Book')}>
+      <a
+        href={ebookUrl}
+        className="ebook-url"
+        onClick={() => gaEvent('E-Book')}
+        aria-label={`Request E-Book: ${book.title}`}
+      >
         <EReaderIcon ariaHidden />
         <span>{config.requestUrlsText.ebook}</span>
       </a> : null;

--- a/src/app/components/Sidebar/Sidebar.jsx
+++ b/src/app/components/Sidebar/Sidebar.jsx
@@ -27,7 +27,9 @@ const Sidebar = (props) => {
     <div className="sidebar nypl-column-one-quarter">
       <nav aria-label="Breadcrumbs">
         <a href={config.recommendationsLink.url} className="back-link">
-          <LeftWedgeIcon title="Return to" ariaHidden={false} /> {config.recommendationsLink.label}
+          <LeftWedgeIcon ariaHidden />
+          <span className="replaced-text visuallyHidden">Return to </span>
+          {config.recommendationsLink.label}
         </a>
       </nav>
       {renderBookFilters(props.isJsEnabled)}

--- a/src/client/styles/components/_hero.scss
+++ b/src/client/styles/components/_hero.scss
@@ -44,7 +44,8 @@
     white-space: normal;
 
     h1 {
-      font-size: 1.8rem;
+      font-family: Milo-Medium;
+      font-size: 2.5rem;
       font-weight: 400;
       line-height: 1.5;
       margin: 0 0 0.75rem 0;

--- a/test/unit/Sidebar.test.js
+++ b/test/unit/Sidebar.test.js
@@ -25,7 +25,8 @@ describe('Sidebar', () => {
       const breadcrumbLink = component.find('a').at(0);
       expect(breadcrumbLink).to.have.length(1);
       // The first part of the "text" is the hidden SVG title which is not hidden in the tests.
-      expect(breadcrumbLink.text()).to.equal('Return to Recommendations');
+      expect(breadcrumbLink.text())
+        .to.equal('NYPL Left Wedge SVG IconReturn to Recommendations');
       expect(breadcrumbLink.prop('href'))
         .to.equal('https://www.nypl.org/books-music-dvds/recommendations');
     });


### PR DESCRIPTION
Fixes #116 

Currently on dev.
![screen shot 2017-11-15 at 12 34 20 pm](https://user-images.githubusercontent.com/1280564/32850887-7bd3720c-ca01-11e7-98db-af1e61a2751f.png)
