### PR TITLE
Breadcrumb text

### DIFF
--- a/src/app/components/BookFilters/BookFilters.jsx
+++ b/src/app/components/BookFilters/BookFilters.jsx
@@ -135,7 +135,9 @@ class BookFilters extends React.Component {
             className="book-filters-toggleButton"
           >
             <LeftWedgeIcon ariaHidden className={buttonAnimationClasses} />
-            <span className="visuallyHidden">{showFilters ? 'Collapse' : 'Expand'}</span>
+            <span className="visuallyHidden">
+              {showFilters ? 'Collapse tag list' : 'Expand tag list'}
+            </span>
           </button>
         </div>
         <div className={`book-filters-list ${filtersContainerDisplayClass}`}>

--- a/src/app/components/Sidebar/Sidebar.jsx
+++ b/src/app/components/Sidebar/Sidebar.jsx
@@ -27,7 +27,9 @@ const Sidebar = (props) => {
     <div className="sidebar nypl-column-one-quarter">
       <nav aria-label="Breadcrumbs">
         <a href={config.recommendationsLink.url} className="back-link">
-          <LeftWedgeIcon title="Return to" ariaHidden={false} /> {config.recommendationsLink.label}
+          <LeftWedgeIcon ariaHidden />
+          <span className="replaced-text visuallyHidden">Return to </span>
+          {config.recommendationsLink.label}
         </a>
       </nav>
       {renderBookFilters(props.isJsEnabled)}

--- a/test/unit/Sidebar.test.js
+++ b/test/unit/Sidebar.test.js
@@ -25,7 +25,8 @@ describe('Sidebar', () => {
       const breadcrumbLink = component.find('a').at(0);
       expect(breadcrumbLink).to.have.length(1);
       // The first part of the "text" is the hidden SVG title which is not hidden in the tests.
-      expect(breadcrumbLink.text()).to.equal('Return to Recommendations');
+      expect(breadcrumbLink.text())
+        .to.equal('NYPL Left Wedge SVG IconReturn to Recommendations');
       expect(breadcrumbLink.prop('href'))
         .to.equal('https://www.nypl.org/books-music-dvds/recommendations');
     });


### PR DESCRIPTION
Fixes the add-on to #113  - updating how "return to" is associated to the SVG in the breadcrumbs.

![screen shot 2017-11-15 at 12 39 15 pm](https://user-images.githubusercontent.com/1280564/32851155-38e351aa-ca02-11e7-9517-5d7be3dd5524.png)

Currently on dev, @wlla  please review on PC, thanks!