### PR TITLE
Chopped off mobile text

### DIFF
--- a/src/client/styles/components/_bookFilters.scss
+++ b/src/client/styles/components/_bookFilters.scss
@@ -4,7 +4,7 @@
     border-top: 4px solid $nypl-red;
 
     h2 {
-      padding: 0px 0 12px 5px;
+      padding: 0px 0 12px 3px;
       font-size: 1rem;
       margin: 15px 0 0;
       font-weight: 200;
@@ -30,7 +30,7 @@
     // book count text
     & > span {
       font-size: 0.78rem;
-      margin: 0 0 0 12px;
+      margin: 0 0 0 10px;
       display: inline-block;
 
       @include min-screen($mobile-breakpoint) {

--- a/src/client/styles/components/_bookFilters.scss
+++ b/src/client/styles/components/_bookFilters.scss
@@ -4,7 +4,7 @@
     border-top: 4px solid $nypl-red;
 
     h2 {
-      padding: 0px 0 12px 3px;
+      padding: 0 0 12px 0;
       font-size: 1rem;
       margin: 15px 0 0;
       font-weight: 200;
@@ -30,7 +30,7 @@
     // book count text
     & > span {
       font-size: 0.78rem;
-      margin: 0 0 0 10px;
+      margin: 0 0 0 8px;
       display: inline-block;
 
       @include min-screen($mobile-breakpoint) {


### PR DESCRIPTION
Fixes (hopefully) #128 

I just add less space to the left of the h2 and the span. The ^ and down arrow button overlaps the text since it's positioned absolute. Let me know if this works.