### PR TITLE
Removing visually hidden css from the app.

### DIFF
--- a/src/app/components/BookFilters/Filter.jsx
+++ b/src/app/components/BookFilters/Filter.jsx
@@ -112,6 +112,7 @@ Filter.propTypes = {
 
 Filter.defaultProps = {
   clearTimeout: () => {},
+  setDisabled: () => {},
 };
 
 export default Filter;

--- a/src/client/styles/utils/_mixins.scss
+++ b/src/client/styles/utils/_mixins.scss
@@ -1,8 +1,3 @@
-@mixin visuallyHidden {
-  width: 1px;
-  height: 1px;
-}
-
 @mixin displayVisuallyHidden {
   position: relative;
   left: 0;

--- a/src/client/styles/utils/_mixins.scss
+++ b/src/client/styles/utils/_mixins.scss
@@ -1,12 +1,3 @@
-@mixin visuallyHidden {
-  position: absolute;
-  left: -10000px;
-  top: auto;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-}
-
 @mixin displayVisuallyHidden {
   position: relative;
   left: 0;

--- a/src/client/styles/utils/_utils.scss
+++ b/src/client/styles/utils/_utils.scss
@@ -1,7 +1,3 @@
-.visuallyHidden {
-  @include visuallyHidden;
-}
-
 .displayVisuallyHidden {
   @include displayVisuallyHidden;
 }


### PR DESCRIPTION
This PR uses the same header we have but removes the `.visuallyHidden` css rule from the app and relies on the one set from Design Toolkit. I'm not sure why we have two different sets but we should just use the DT rule.

This solves the problem of the NYPL Logo and the Locations link not being tappable on VO on mobile devices. The only issue is how the VO focus wraps the element. It should be address but I'm not sure how to start that and I think @ricardoom mentioned it could be the SVG box (?).

Related Header tickets: [HDR-21](https://jira.nypl.org/browse/HDR-21) [HDR-12](https://jira.nypl.org/browse/HDR-12)

Currently up on dev: http://staff-picks-dev.us-east-1.elasticbeanstalk.com/books-music-dvds/recommendations/best-books/ya

![image uploaded from ios 5](https://user-images.githubusercontent.com/1280564/33634253-95f83a38-d9e1-11e7-8bff-852d809830f9.png)
