### PR TITLE
Handle input and route for audience

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -117,7 +117,7 @@ By using the `aws-cli`, developers can deploy the application to the AWS applica
 | AWS Profile | Application Name | Environment |
 |---|---|---|
 | `nypl-digital-dev` | `nypl-staff-picks-app` | **QA**: `staff-picks-qa` <br><br> **Production**: `staff-picks-production` |
-| `nypl-sandbox` | `nypl-staff-picks-app` | **Development**: `staff-picks-dev`
+| `nypl-sandbox` | `nypl-staff-picks-app` | **Development**: `staff-picks-development`
 
 > Note: All QA and Development servers should be configured with only 1 instance. Production servers are typically setup with auto-scaling supporting 2 or more instances.
 

--- a/src/app/actions/BookActions.js
+++ b/src/app/actions/BookActions.js
@@ -2,6 +2,10 @@
 import alt from '../alt';
 
 class Actions {
+  updateListType(listType) {
+    return listType;
+  }
+
   updatePicks(picks) {
     return picks;
   }

--- a/src/app/actions/BookActions.js
+++ b/src/app/actions/BookActions.js
@@ -10,6 +10,14 @@ class Actions {
     return filters;
   }
 
+  updateCurrentSeason(season) {
+    return season;
+  }
+
+  updateCurrentAudience(audience) {
+    return audience;
+  }
+
   setIsJsEnabled(bool) {
     return bool;
   }

--- a/src/app/components/Application/Main.jsx
+++ b/src/app/components/Application/Main.jsx
@@ -22,9 +22,6 @@ class Main extends React.Component {
   }
 
   componentWillReceiveProps() {
-    // Temperorily logging for development
-    console.log('update new props!');
-
     // Update the props to reflect the latest updates from client side API responses
     this.setState({
       selectableFilters: this.props.selectableFilters,
@@ -110,6 +107,34 @@ class Main extends React.Component {
     });
   }
 
+  /**
+   * extractAudienceGroup(picks, audience)
+   * Picks up the items from the selected age/audience group
+   * @param {array} picks
+   * @param {string} audience
+   */
+  extractAudienceGroup(picks, audience) {
+    console.log(this.props.listType);
+
+    // Only applies the check for staff-picks lists
+    if (this.props.listType !== 'staff-picks') {
+      // skips the checks and returns the original picks
+      return picks;
+    }
+
+    const audienceGroup = [];
+
+    if (Array.isArray(picks) && picks.length) {
+      picks.map((item) => {
+        if (item.ageGroup === audience) {
+          audienceGroup.push(item);
+        }
+      });
+    }
+
+    return audienceGroup;
+  }
+
   render() {
     return (
       <div className="nypl-row">
@@ -126,7 +151,7 @@ class Main extends React.Component {
         />
 
         <BookList
-          picks={this.state.picks}
+          picks={this.extractAudienceGroup(this.state.picks, this.props.currentAudience)}
           isJsEnabled={this.props.isJsEnabled}
           listType={this.props.params.type}
         />
@@ -141,6 +166,9 @@ Main.propTypes = {
   currentPicks: PropTypes.object,
   isJsEnabled: PropTypes.bool,
   params: PropTypes.object,
+  listType: PropTypes.string,
+  currentSeason: PropTypes.string,
+  currentAudience: PropTypes.string,
 };
 
 Main.defaultProps = {

--- a/src/app/components/Application/Main.jsx
+++ b/src/app/components/Application/Main.jsx
@@ -108,16 +108,15 @@ class Main extends React.Component {
   }
 
   /**
-   * extractAudienceGroup(picks, audience)
+   * extractAudienceGroup(picks, audience, listType)
    * Picks up the items from the selected age/audience group
    * @param {array} picks
    * @param {string} audience
+   * @param {string} listType
    */
-  extractAudienceGroup(picks, audience) {
-    console.log(this.props.listType);
-
+  extractAudienceGroup(picks, audience, listType) {
     // Only applies the check for staff-picks lists
-    if (this.props.listType !== 'staff-picks') {
+    if (listType !== 'staff-picks') {
       // skips the checks and returns the original picks
       return picks;
     }
@@ -151,7 +150,11 @@ class Main extends React.Component {
         />
 
         <BookList
-          picks={this.extractAudienceGroup(this.state.picks, this.props.currentAudience)}
+          picks={this.extractAudienceGroup(
+            this.state.picks,
+            this.props.currentAudience,
+            this.props.listType
+          )}
           isJsEnabled={this.props.isJsEnabled}
           listType={this.props.params.type}
         />

--- a/src/app/components/Application/Main.jsx
+++ b/src/app/components/Application/Main.jsx
@@ -121,6 +121,8 @@ class Main extends React.Component {
           isJsEnabled={this.props.isJsEnabled}
           selectedFilters={this.state.selectedFilters}
           picksCount={this.state.picks.length}
+          currentSeason={this.props.currentSeason}
+          currentAudience={this.props.currentAudience}
         />
 
         <BookList

--- a/src/app/components/ListSelector/ListFilter.jsx
+++ b/src/app/components/ListSelector/ListFilter.jsx
@@ -9,7 +9,7 @@ const ListFilter = ({ fieldsetProps, listType, handleChange }) => {
   // const defaultValue = (fieldsetProps.options.length && fieldsetProps.options[0].value) ?
   //   fieldsetProps.options[0].value : '';
   const optionList = (fieldsetProps.options.length) ? fieldsetProps.options.map(
-    (opt) => <option value={opt.value} key={opt.value}>{opt.name}</option>
+    (opt) => <option value={opt.value} disabled={opt.disabled} key={opt.value}>{opt.name}</option>
   ) : null;
 
   if (fieldsetProps.currentValue) {

--- a/src/app/components/ListSelector/ListFilter.jsx
+++ b/src/app/components/ListSelector/ListFilter.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const ListFilter = ({ fieldsetProps, handleChange }) => {
+const ListFilter = ({ fieldsetProps, listType, handleChange }) => {
   const selectName = fieldsetProps.fieldsetName;
   const selectId = `${selectName}-input`;
   let defaultValue;
@@ -26,7 +26,7 @@ const ListFilter = ({ fieldsetProps, handleChange }) => {
         id={selectId}
         name={selectName}
         defaultValue={defaultValue}
-        onChange={handleChange}
+        onChange={(e) => { handleChange(listType, e); }}
       >
        {optionList}
       </select>

--- a/src/app/components/ListSelector/ListFilter.jsx
+++ b/src/app/components/ListSelector/ListFilter.jsx
@@ -5,11 +5,19 @@ import PropTypes from 'prop-types';
 const ListFilter = ({ fieldsetProps, handleChange }) => {
   const selectName = fieldsetProps.fieldsetName;
   const selectId = `${selectName}-input`;
-  const defaultValue = (fieldsetProps.options.length && fieldsetProps.options[0].value) ?
-    fieldsetProps.options[0].value : '';
+  let defaultValue;
+  // const defaultValue = (fieldsetProps.options.length && fieldsetProps.options[0].value) ?
+  //   fieldsetProps.options[0].value : '';
   const optionList = (fieldsetProps.options.length) ? fieldsetProps.options.map(
     (opt) => <option value={opt.value} key={opt.value}>{opt.name}</option>
   ) : null;
+
+  if (fieldsetProps.currentValue) {
+    defaultValue = fieldsetProps.currentValue;
+  } else {
+    defaultValue = (fieldsetProps.options.length && fieldsetProps.options[0].value) ?
+      fieldsetProps.options[0].value : '';
+  }
 
   return (
     <fieldset>

--- a/src/app/components/ListSelector/ListSelector.jsx
+++ b/src/app/components/ListSelector/ListSelector.jsx
@@ -49,12 +49,20 @@ class ListSelector extends React.Component {
    * @param {array} filters
    * @param {array} selectedFilters
    */
-  updateBookStore(picks = {}, currentSeason = '', currentAudience = 'adult', filters = [], selectedFilters = []) {
+  updateBookStore(
+    picks = {},
+    currentSeason = '',
+    currentAudience = 'adult',
+    listType = 'staff-picks',
+    filters = [],
+    selectedFilters = []
+  ) {
     BookActions.updatePicks(picks);
     BookActions.updateCurrentSeason(currentSeason);
     BookActions.updateCurrentAudience(currentAudience);
     BookActions.updateFilters(filters);
     BookActions.setSelectableFilters(selectedFilters);
+    BookActions.updateListType(listType);
   }
 
   /**
@@ -66,7 +74,6 @@ class ListSelector extends React.Component {
   submitFormRequest(listType, submitValue) {
     let seasonValue = this.props.fieldsetProps.season.currentValue;
     let audienceValue = this.props.fieldsetProps.audience.currentValue;
-    let audienceQuery = `?audience=${audienceValue}`;
 
     if (listType === 'season') {
       seasonValue = submitValue;
@@ -74,11 +81,11 @@ class ListSelector extends React.Component {
 
     if (listType === 'audience') {
       audienceValue = submitValue;
-      audienceQuery =`?audience=${audienceValue}`;
+      audienceQuery = `?audience=${audienceValue}`;
     }
 
     // this function will be replaced by submiting to endpoint
-    axios.get(`${config.baseApiUrl}${seasonValue}${audienceQuery}`)
+    axios.get(`${config.baseApiUrl}${seasonValue}`)
       .then(response => {
         // Catch the error from API, and update BookStore back to the default
         if (response.data.statusCode >= 400) {
@@ -90,7 +97,12 @@ class ListSelector extends React.Component {
           this.updateHistory('/books-music-dvds/recommendations/staff-picks/404');
         } else {
           // For valid API response, update BookStore for the new list
-          this.updateBookStore(response.data.currentPicks, seasonValue, audienceValue);
+          this.updateBookStore(
+            response.data.currentPicks,
+            seasonValue,
+            audienceValue,
+            'staff-picks'
+          );
           // Update and transit to the match URL
           this.updateHistory(
             `/books-music-dvds/recommendations/staff-picks/${seasonValue}-01/`

--- a/src/app/components/ListSelector/ListSelector.jsx
+++ b/src/app/components/ListSelector/ListSelector.jsx
@@ -58,13 +58,27 @@ class ListSelector extends React.Component {
   }
 
   /**
-   * submitFormRequest(submitValue)
+   * submitFormRequest(listType, submitValue)
    * Submits the request for a new list to the internal server
+   * @param {string} listType
    * @param {string} submitValue
    */
-  submitFormRequest(submitValue) {
+  submitFormRequest(listType, submitValue) {
+    let seasonValue = this.props.fieldsetProps.season.currentValue;
+    let audienceValue = this.props.fieldsetProps.audience.currentValue;
+    let audienceQuery = `?audience=${audienceValue}`;
+
+    if (listType === 'season') {
+      seasonValue = submitValue;
+    }
+
+    if (listType === 'audience') {
+      audienceValue = submitValue;
+      audienceQuery =`?audience=${audienceValue}`;
+    }
+
     // this function will be replaced by submiting to endpoint
-    axios.get(`${config.baseApiUrl}${submitValue}`)
+    axios.get(`${config.baseApiUrl}${seasonValue}${audienceQuery}`)
       .then(response => {
         // Catch the error from API, and update BookStore back to the default
         if (response.data.statusCode >= 400) {
@@ -76,10 +90,10 @@ class ListSelector extends React.Component {
           this.updateHistory('/books-music-dvds/recommendations/staff-picks/404');
         } else {
           // For valid API response, update BookStore for the new list
-          this.updateBookStore(response.data.currentPicks, submitValue);
+          this.updateBookStore(response.data.currentPicks, seasonValue, audienceValue);
           // Update and transit to the match URL
           this.updateHistory(
-            `/books-music-dvds/recommendations/staff-picks/${submitValue}-01/`
+            `/books-music-dvds/recommendations/staff-picks/${seasonValue}-01/`
           );
         }
       })
@@ -105,8 +119,8 @@ class ListSelector extends React.Component {
    * Triggers to submit requests when the selected value changed on the season or audience lists
    * @param {DOM event} e
    */
-  handleChange(e) {
-    this.submitFormRequest(e.target.value);
+  handleChange(listType, e) {
+    this.submitFormRequest(listType, e.target.value);
   }
 
   /**
@@ -119,10 +133,13 @@ class ListSelector extends React.Component {
       return null;
     }
 
+    const listType = fieldsetProps.fieldsetName;
+
     return (
       <ListFilter
         fieldsetProps={fieldsetProps}
         handleChange={this.handleChange}
+        listType={listType}
       />
     );
   }

--- a/src/app/components/ListSelector/ListSelector.jsx
+++ b/src/app/components/ListSelector/ListSelector.jsx
@@ -115,8 +115,9 @@ class ListSelector extends React.Component {
   }
 
   /**
-   * handleChange(e)
+   * handleChange(listType, e)
    * Triggers to submit requests when the selected value changed on the season or audience lists
+   * @param {string} listType
    * @param {DOM event} e
    */
   handleChange(listType, e) {

--- a/src/app/components/ListSelector/ListSelector.jsx
+++ b/src/app/components/ListSelector/ListSelector.jsx
@@ -49,8 +49,10 @@ class ListSelector extends React.Component {
    * @param {array} filters
    * @param {array} selectedFilters
    */
-  updateBookStore(picks = {}, filters = [], selectedFilters = []) {
+  updateBookStore(picks = {}, currentSeason = '', currentAudience = 'adult', filters = [], selectedFilters = []) {
     BookActions.updatePicks(picks);
+    BookActions.updateCurrentSeason(currentSeason);
+    BookActions.updateCurrentAudience(currentAudience);
     BookActions.updateFilters(filters);
     BookActions.setSelectableFilters(selectedFilters);
   }
@@ -74,7 +76,7 @@ class ListSelector extends React.Component {
           this.updateHistory('/books-music-dvds/recommendations/staff-picks/404');
         } else {
           // For valid API response, update BookStore for the new list
-          this.updateBookStore(response.data.currentPicks);
+          this.updateBookStore(response.data.currentPicks, submitValue);
           // Update and transit to the match URL
           this.updateHistory(
             `/books-music-dvds/recommendations/staff-picks/${submitValue}-01/`
@@ -118,7 +120,10 @@ class ListSelector extends React.Component {
     }
 
     return (
-      <ListFilter fieldsetProps={fieldsetProps} handleChange={this.handleChange} />
+      <ListFilter
+        fieldsetProps={fieldsetProps}
+        handleChange={this.handleChange}
+      />
     );
   }
 

--- a/src/app/components/ListSelector/ListSelector.jsx
+++ b/src/app/components/ListSelector/ListSelector.jsx
@@ -65,7 +65,6 @@ class ListSelector extends React.Component {
 
     if (listType === 'audience') {
       audienceValue = submitValue;
-      audienceQuery = `?audience=${audienceValue}`;
     }
 
     // this function will be replaced by submiting to endpoint

--- a/src/app/components/Sidebar/Sidebar.jsx
+++ b/src/app/components/Sidebar/Sidebar.jsx
@@ -23,20 +23,20 @@ const fieldsetProps = {
     fieldsetName: 'audience',
     currentValue: '',
     options: [
-      { name: 'Adult', value: 'adult', disabled: false },
-      { name: 'Teen', value: 'ya', disabled: false },
-      { name: 'Children', value: 'children', disabled: false },
+      { name: 'Adult', value: 'Adult', disabled: false },
+      { name: 'Teen', value: 'YA', disabled: false },
+      { name: 'Children', value: 'Children', disabled: false },
     ],
   },
 };
 
 const Sidebar = (props) => {
   const updateCurrentListSelectorValue = (data) => {
-    fieldsetProps.season.currentValue =  data.currentSeason;
-    fieldsetProps.audience.currentValue =  data.currentAudience;
+    fieldsetProps.season.currentValue = data.currentSeason;
+    fieldsetProps.audience.currentValue = data.currentAudience;
 
     return fieldsetProps;
-  }
+  };
 
   const renderBookFilters = (shouldDisplay) => {
     if (!shouldDisplay) {

--- a/src/app/components/Sidebar/Sidebar.jsx
+++ b/src/app/components/Sidebar/Sidebar.jsx
@@ -10,6 +10,7 @@ import config from '../../../../appConfig';
 const fieldsetProps = {
   season: {
     fieldsetName: 'season',
+    currentValue: '',
     options: [
       { name: '2018 Winter', value: '2018-01' },
       { name: '2017 Fall', value: '2017-09' },
@@ -19,6 +20,7 @@ const fieldsetProps = {
   },
   audience: {
     fieldsetName: 'audience',
+    currentValue: '',
     options: [
       { name: 'Adult', value: 'adult' },
       { name: 'Teen', value: 'ya' },
@@ -28,6 +30,13 @@ const fieldsetProps = {
 };
 
 const Sidebar = (props) => {
+  const updateCurrentListSelectorValue = (data) => {
+    fieldsetProps.season.currentValue =  data.currentSeason;
+    fieldsetProps.audience.currentValue =  data.currentAudience;
+
+    return fieldsetProps;
+  }
+
   const renderBookFilters = (shouldDisplay) => {
     if (!shouldDisplay) {
       return null;
@@ -46,7 +55,10 @@ const Sidebar = (props) => {
   };
 
   const renderListSelector = (data) =>
-    <ListSelector fieldsetProps={data} isJsEnabled={props.isJsEnabled} />;
+    <ListSelector
+      fieldsetProps={data}
+      isJsEnabled={props.isJsEnabled}
+    />;
 
   return (
     <div className="sidebar nypl-column-one-quarter">
@@ -57,7 +69,7 @@ const Sidebar = (props) => {
           {config.recommendationsLink.label}
         </a>
       </nav>
-      {renderListSelector(fieldsetProps)}
+      {renderListSelector(updateCurrentListSelectorValue(props))}
       {renderBookFilters(props.isJsEnabled)}
     </div>
   );

--- a/src/app/components/Sidebar/Sidebar.jsx
+++ b/src/app/components/Sidebar/Sidebar.jsx
@@ -12,19 +12,20 @@ const fieldsetProps = {
     fieldsetName: 'season',
     currentValue: '',
     options: [
-      { name: '2018 Winter', value: '2018-01' },
-      { name: '2017 Fall', value: '2017-09' },
-      { name: '2017 Summer', value: '2017-06' },
-      { name: '2017 Spring', value: '2017-04' },
+      { name: '2018 Winter', value: '2018-01', disabled: false },
+      { name: '2017 Fall', value: '2017-09', disabled: true },
+      { name: '2017 Summer', value: '2017-06', disabled: true },
+      { name: '2017 Spring', value: '2017-04', disabled: true },
+      { name: '2017 Winter', value: '2017-01', disabled: false },
     ],
   },
   audience: {
     fieldsetName: 'audience',
     currentValue: '',
     options: [
-      { name: 'Adult', value: 'adult' },
-      { name: 'Teen', value: 'ya' },
-      { name: 'Children', value: 'children' },
+      { name: 'Adult', value: 'adult', disabled: false },
+      { name: 'Teen', value: 'ya', disabled: false },
+      { name: 'Children', value: 'children', disabled: false },
     ],
   },
 };

--- a/src/app/stores/BookStore.js
+++ b/src/app/stores/BookStore.js
@@ -5,6 +5,7 @@ import BookActions from '../actions/BookActions';
 class BookStore {
   constructor() {
     this.bindListeners({
+      updateListType: BookActions.UPDATE_LIST_TYPE,
       updatePicks: BookActions.UPDATE_PICKS,
       updateFilters: BookActions.UPDATE_FILTERS,
       updateCurrentSeason: BookActions.UPDATE_CURRENT_SEASON,
@@ -14,6 +15,7 @@ class BookStore {
     });
 
     this.state = {
+      listType: '',
       filters: [],
       currentPicks: {},
       isJsEnabled: false,
@@ -21,6 +23,10 @@ class BookStore {
       currentSeason: '',
       currentAudience: '',
     };
+  }
+
+  updateListType(listType) {
+    this.setState({ listType });
   }
 
   updatePicks(currentPicks) {

--- a/src/app/stores/BookStore.js
+++ b/src/app/stores/BookStore.js
@@ -7,6 +7,8 @@ class BookStore {
     this.bindListeners({
       updatePicks: BookActions.UPDATE_PICKS,
       updateFilters: BookActions.UPDATE_FILTERS,
+      updateCurrentSeason: BookActions.UPDATE_CURRENT_SEASON,
+      updateCurrentAudience: BookActions.UPDATE_CURRENT_AUDIENCE,
       setIsJsEnabled: BookActions.SET_IS_JS_ENABLED,
       setSelectableFilters: BookActions.SET_SELECTABLE_FILTERS,
     });
@@ -16,6 +18,8 @@ class BookStore {
       currentPicks: {},
       isJsEnabled: false,
       selectableFilters: [],
+      currentSeason: '',
+      currentAudience: '',
     };
   }
 
@@ -25,6 +29,14 @@ class BookStore {
 
   updateFilters(filters) {
     this.setState({ filters });
+  }
+
+  updateCurrentSeason(currentSeason) {
+    this.setState({ currentSeason });
+  }
+
+  updateCurrentAudience(currentAudience) {
+    this.setState({ currentAudience });
   }
 
   setIsJsEnabled(isJsEnabled) {

--- a/src/server/routes/monthData.js
+++ b/src/server/routes/monthData.js
@@ -2,9 +2,9 @@ import nyplApiClient from '../helper/nyplApiClient.js';
 import config from '../../../appConfig';
 
 const getLatestSeason = () => {
-  //this function should return the latest season by current month
+  // this function should return the latest season by current month
   return '';
-}
+};
 
 const nyplApiClientGet = (endpoint) =>
   nyplApiClient().then(client => client.get(endpoint, { cache: false }));
@@ -20,12 +20,13 @@ function currentMonthData(req, res, next) {
     .then(data => {
       res.locals.data = {
         BookStore: {
+          listType: 'staff-picks',
           filters: [],
           currentPicks: data,
           selectableFilters: [],
           isJsEnabled: false,
           currentSeason: getLatestSeason(),
-          currentAudience: 'adult',
+          currentAudience: 'Adult',
         },
         pageTitle: '',
         metaTags: [],
@@ -38,12 +39,13 @@ function currentMonthData(req, res, next) {
 
       res.locals.data = {
         BookStore: {
+          listType: 'staff-picks',
           filters: [],
           currentPicks: {},
           selectableFilters: [],
           isJsEnabled: false,
           currentSeason: getLatestSeason(),
-          currentAudience: 'adult',
+          currentAudience: 'Adult',
         },
       };
 
@@ -58,16 +60,13 @@ function selectMonthData(req, res, next) {
   // Checks if the URL input fits season's convention
   const seasonMatches = req.params.month.match(/^(\d{4})\-(\d{2})\-(\d{2})$/);
   // Default audience list is the adult list
-  let audience = 'adult';
-  let requestedAudience = '';
+  let audience = 'Adult';
   let requestedSeason = '';
 
   // Checks if req.query.audience exists and equals to one of the three values
-  if (['adult', 'ya', 'children'].includes(req.query.audience)) {
+  if (['Adult', 'YA', 'Children'].includes(req.query.audience)) {
     // If so, updates the selected audience list value
     audience = req.query.audience;
-    // And, constructs audience query
-    requestedAudience = `?audience=${audience}`;
   }
 
   // If the param does not fit season's convention, throws an error
@@ -76,12 +75,13 @@ function selectMonthData(req, res, next) {
 
     res.locals.data = {
       BookStore: {
+        listType: 'staff-picks',
         filters: [],
         currentPicks: {},
         selectableFilters: [],
         isJsEnabled: false,
         currentSeason: getLatestSeason(),
-        currentAudience: 'adult',
+        currentAudience: 'Adult',
       },
     };
 
@@ -94,10 +94,11 @@ function selectMonthData(req, res, next) {
   // Now the audience query seems to have no influence to the API,
   // as it will always throw the adult lists
   // But we should show the audience we choose on the URL and selected value on the list
-  nyplApiClientGet(`/book-lists/staff-picks/${requestedSeason}${requestedAudience}`)
+  nyplApiClientGet(`/book-lists/staff-picks/${requestedSeason}`)
     .then(data => {
       res.locals.data = {
         BookStore: {
+          listType: 'staff-picks',
           filters: [],
           currentPicks: data,
           selectableFilters: [],
@@ -116,12 +117,13 @@ function selectMonthData(req, res, next) {
 
       res.locals.data = {
         BookStore: {
+          listType: 'staff-picks',
           filters: [],
           currentPicks: {},
           selectableFilters: [],
           isJsEnabled: false,
           currentSeason: getLatestSeason(),
-          currentAudience: 'adult',
+          currentAudience: 'Adult',
         },
       };
 
@@ -135,13 +137,6 @@ function selectMonthData(req, res, next) {
  */
 function selectClientMonthData(req, res) {
   const seasonMatches = req.params.month.match(/^(\d{4})\-(\d{2})$/);
-  let audienceQuery = '';
-
-  // Checks if req.query.audience exists and equals to one of the three values
-  if (['adult', 'ya', 'children'].includes(req.query.audience)) {
-    // If so, constructs the audience query
-    audienceQuery = `?audience=${req.query.audience}`;
-  }
 
   if (!seasonMatches) {
     console.error('Status Code: 400, Error Message: Invalid season.');
@@ -152,7 +147,7 @@ function selectClientMonthData(req, res) {
     });
   }
 
-  nyplApiClientGet(`/book-lists/staff-picks/${req.params.month}${audienceQuery}`)
+  nyplApiClientGet(`/book-lists/staff-picks/${req.params.month}`)
     .then(data => {
       res.json({
         title: data.title,
@@ -187,6 +182,7 @@ function selectClientMonthDataPost(req, res) {
     );
   }
 
+  // Redirects and calls selectMonthData() to make server side request for the season/audience list
   res.redirect(
     `${config.baseMonthUrl}${season}${audience}`
   );

--- a/src/server/routes/monthData.js
+++ b/src/server/routes/monthData.js
@@ -57,7 +57,6 @@ function currentMonthData(req, res, next) {
  * Get a specific month's or season's staff pick list.
  */
 function selectMonthData(req, res, next) {
-<<<<<<< HEAD
   // Checks if the URL input fits season's convention
   const seasonMatches = req.params.month.match(/^(\d{4})\-(\d{2})\-(\d{2})$/);
   // Default audience list is the adult list

--- a/src/server/routes/monthData.js
+++ b/src/server/routes/monthData.js
@@ -175,6 +175,7 @@ function selectClientMonthData(req, res) {
 function selectMonthDataFormPost(req, res) {
   const season = (req.body.season) ? `${req.body.season}` : '';
   const audience = req.body.audience;
+  const audienceQuery = audience ? `?audience=${audience}` : '';
 
   if (!season || !audience) {
     console.log(
@@ -184,7 +185,7 @@ function selectMonthDataFormPost(req, res) {
 
   // Redirects and calls selectMonthData() to make server side request for the season/audience list
   res.redirect(
-    `${config.baseMonthUrl}${season}${audience}`
+    `${config.baseMonthUrl}${season}${audienceQuery}`
   );
 }
 

--- a/src/server/routes/monthData.js
+++ b/src/server/routes/monthData.js
@@ -1,6 +1,11 @@
 import nyplApiClient from '../helper/nyplApiClient.js';
 import config from '../../../appConfig';
 
+const getLatestSeason = () => {
+  //this function should return the latest season by current month
+  return '';
+}
+
 const nyplApiClientGet = (endpoint) =>
   nyplApiClient().then(client => client.get(endpoint, { cache: false }));
 
@@ -18,64 +23,7 @@ function currentMonthData(req, res, next) {
           currentPicks: data,
           selectableFilters: [],
           isJsEnabled: false,
-        },
-        pageTitle: '',
-        metaTags: [],
-      };
-
-      next();
-    })
-    .catch(error => {
-      console.error(`Status Code: ${error.statusCode}, Error Message: ${error.code}`);
-
-      res.locals.data = {
-        BookStore: {
-          filters: [],
-          currentPicks: {},
-          selectableFilters: [],
-          isJsEnabled: false,
-        },
-      };
-
-      next();
-    });
-}
-
-/* selectMonthData
- * Get a specific month's or season's staff pick list.
- */
-function selectMonthData(req, res, next) {
-
-  // Checks if the URL input fits season's convention
-  const seasonMatches = req.params.month.match(/^(\d{4})\-(\d{2})\-(\d{2})$/);
-
-  // If no, throw an error
-  if (!seasonMatches) {
-    console.error('Status Code: 400, Error Message: Invalid season.');
-
-    res.locals.data = {
-      BookStore: {
-        filters: [],
-        currentPicks: {},
-        selectableFilters: [],
-        isJsEnabled: false,
-      },
-    };
-
-    next();
-  }
-
-  // only 2017-01 works currently. Comment out the dynamice API link below
-  // nyplApiClientGet(`/book-lists/staff-picks/${req.params.month}`)
-  nyplApiClientGet('/book-lists/staff-picks/2017-01')
-    .then(data => {
-      res.locals.data = {
-        BookStore: {
-          filters: [],
-          currentPicks: data,
-          selectableFilters: [],
-          isJsEnabled: false,
-          currentSeason: `${seasonMatches[1]}-${seasonMatches[2]}`,
+          currentSeason: getLatestSeason(),
           currentAudience: 'adult',
         },
         pageTitle: '',
@@ -93,6 +41,73 @@ function selectMonthData(req, res, next) {
           currentPicks: {},
           selectableFilters: [],
           isJsEnabled: false,
+          currentSeason: getLatestSeason(),
+          currentAudience: 'adult',
+        },
+      };
+
+      next();
+    });
+}
+
+/* selectMonthData
+ * Get a specific month's or season's staff pick list.
+ */
+function selectMonthData(req, res, next) {
+  // Checks if the URL input fits season's convention
+  const seasonMatches = req.params.month.match(/^(\d{4})\-(\d{2})\-(\d{2})$/);
+  const audience = req.query.audience;
+
+  // should add a check for req.query.audience here
+
+  // If no, throw an error
+  if (!seasonMatches) {
+    console.error('Status Code: 400, Error Message: Invalid season.');
+
+    res.locals.data = {
+      BookStore: {
+        filters: [],
+        currentPicks: {},
+        selectableFilters: [],
+        isJsEnabled: false,
+        currentSeason: getLatestSeason(),
+        currentAudience: 'adult',
+      },
+    };
+
+    next();
+  }
+
+  // only 2017-01 works currently. Comment out the dynamice API link below
+  // nyplApiClientGet(`/book-lists/staff-picks/${req.params.month}`)
+  nyplApiClientGet(`/book-lists/staff-picks/2017-01?audience=${audience}`)
+    .then(data => {
+      res.locals.data = {
+        BookStore: {
+          filters: [],
+          currentPicks: data,
+          selectableFilters: [],
+          isJsEnabled: false,
+          currentSeason: `${seasonMatches[1]}-${seasonMatches[2]}`,
+          currentAudience: audience,
+        },
+        pageTitle: '',
+        metaTags: [],
+      };
+
+      next();
+    })
+    .catch(error => {
+      console.error(`Status Code: ${error.statusCode}, Error Message: ${error.code}`);
+
+      res.locals.data = {
+        BookStore: {
+          filters: [],
+          currentPicks: {},
+          selectableFilters: [],
+          isJsEnabled: false,
+          currentSeason: getLatestSeason(),
+          currentAudience: 'adult',
         },
       };
 
@@ -134,7 +149,7 @@ function selectClientMonthData(req, res) {
  */
 function selectClientMonthDataPost(req, res) {
   const season = (req.body.season) ? `${req.body.season}-01` : '';
-  const audience = req.body.audience;
+  const audience = (req.body.audience) ? `?audience=${req.body.audience}` : '';
 
   if (!season || !audience) {
     console.log(
@@ -143,7 +158,7 @@ function selectClientMonthDataPost(req, res) {
   }
 
   res.redirect(
-    `${config.baseMonthUrl}${season}`
+    `${config.baseMonthUrl}${season}${audience}`
   );
 }
 

--- a/src/server/routes/monthData.js
+++ b/src/server/routes/monthData.js
@@ -13,9 +13,8 @@ const nyplApiClientGet = (endpoint) =>
  * Get the default/latest monthly staff pick list.
  */
 function currentMonthData(req, res, next) {
-  // only 2017-01 works currently. Comment out the dynamice API link below
-  // nyplApiClientGet(`/book-lists/staff-picks/${req.params.month}`)
-  nyplApiClientGet('/book-lists/staff-picks/2017-01')
+  // should get the latest list from the function getLatestSeason()
+  nyplApiClientGet('/book-lists/staff-picks/2018-01')
     .then(data => {
       res.locals.data = {
         BookStore: {
@@ -57,6 +56,7 @@ function selectMonthData(req, res, next) {
   // Checks if the URL input fits season's convention
   const seasonMatches = req.params.month.match(/^(\d{4})\-(\d{2})\-(\d{2})$/);
   const audience = req.query.audience;
+  let requestedSeason = '';
 
   // should add a check for req.query.audience here
 
@@ -76,11 +76,11 @@ function selectMonthData(req, res, next) {
     };
 
     next();
+  } else {
+    requestedSeason = `${seasonMatches[1]}-${seasonMatches[2]}`;
   }
 
-  // only 2017-01 works currently. Comment out the dynamice API link below
-  // nyplApiClientGet(`/book-lists/staff-picks/${req.params.month}`)
-  nyplApiClientGet(`/book-lists/staff-picks/2017-01?audience=${audience}`)
+  nyplApiClientGet(`/book-lists/staff-picks/${requestedSeason}?audience=${audience}`)
     .then(data => {
       res.locals.data = {
         BookStore: {
@@ -88,7 +88,7 @@ function selectMonthData(req, res, next) {
           currentPicks: data,
           selectableFilters: [],
           isJsEnabled: false,
-          currentSeason: `${seasonMatches[1]}-${seasonMatches[2]}`,
+          currentSeason: requestedSeason,
           currentAudience: audience,
         },
         pageTitle: '',
@@ -120,9 +120,18 @@ function selectMonthData(req, res, next) {
  * Gets a specific month's or season's staff pick list on the client side.
  */
 function selectClientMonthData(req, res) {
-  // only 2017-01 works currently. Comment out the dynamice API link below
-  // nyplApiClientGet(`/book-lists/staff-picks/${req.params.month}`)
-  nyplApiClientGet('/book-lists/staff-picks/2017-01')
+  const seasonMatches = req.params.month.match(/^(\d{4})\-(\d{2})$/);
+
+  if (!seasonMatches) {
+    console.error('Status Code: 400, Error Message: Invalid season.');
+
+    res.json({
+      statusCode: 400,
+      errorMessage: 'Invalid season.',
+    });
+  }
+
+  nyplApiClientGet(`/book-lists/staff-picks/${req.params.month}`)
     .then(data => {
       res.json({
         title: data.title,

--- a/src/server/routes/monthData.js
+++ b/src/server/routes/monthData.js
@@ -45,6 +45,26 @@ function currentMonthData(req, res, next) {
  * Get a specific month's or season's staff pick list.
  */
 function selectMonthData(req, res, next) {
+
+  // Checks if the URL input fits season's convention
+  const seasonMatches = req.params.month.match(/^(\d{4})\-(\d{2})\-(\d{2})$/);
+
+  // If no, throw an error
+  if (!seasonMatches) {
+    console.error('Status Code: 400, Error Message: Invalid season.');
+
+    res.locals.data = {
+      BookStore: {
+        filters: [],
+        currentPicks: {},
+        selectableFilters: [],
+        isJsEnabled: false,
+      },
+    };
+
+    next();
+  }
+
   // only 2017-01 works currently. Comment out the dynamice API link below
   // nyplApiClientGet(`/book-lists/staff-picks/${req.params.month}`)
   nyplApiClientGet('/book-lists/staff-picks/2017-01')
@@ -55,6 +75,8 @@ function selectMonthData(req, res, next) {
           currentPicks: data,
           selectableFilters: [],
           isJsEnabled: false,
+          currentSeason: `${seasonMatches[1]}-${seasonMatches[2]}`,
+          currentAudience: 'adult',
         },
         pageTitle: '',
         metaTags: [],

--- a/test/unit/ListSelector.test.js
+++ b/test/unit/ListSelector.test.js
@@ -21,11 +21,11 @@ const fieldsetProps = {
   },
   audience: {
     fieldsetName: 'audience',
-    currentValue: 'adult',
+    currentValue: 'Adult',
     options: [
-      { name: 'Adult', value: 'adult' },
-      { name: 'Teen', value: 'ya' },
-      { name: 'Children', value: 'children' },
+      { name: 'Adult', value: 'Adult' },
+      { name: 'Teen', value: 'YA' },
+      { name: 'Children', value: 'Children' },
     ],
   },
 };
@@ -108,7 +108,7 @@ describe('ListSelector', () => {
           statusText: 'Undefined error',
           status: 500,
         })
-        .onGet(`${config.baseApiUrl}2017-01?audience=adult`)
+        .onGet(`${config.baseApiUrl}2017-01`)
         .reply(200, mockBookListResponse);
     });
 
@@ -164,7 +164,7 @@ describe('ListSelector', () => {
         () => {
           expect(updateBookStore.called).to.equal(true);
           expect(updateBookStore.getCall(0).args).to.deep.equal(
-            [mockBookListResponse.currentPicks, '2017-01', 'adult']
+            [mockBookListResponse.currentPicks, '2017-01', 'Adult', "staff-picks"]
           );
 
           done();

--- a/test/unit/ListSelector.test.js
+++ b/test/unit/ListSelector.test.js
@@ -132,13 +132,22 @@ describe('ListSelector', () => {
     // To prevent that, we pass "done" to make this test async, and then we call "done()" to mark
     // the point where the current test is completed. The mark tells chai it is the time to do the
     // next test.
-    it('should set BookStore back to the default and set URL to the 404 page, if the request fails.', (done) => {
+    it('should set BookStore back to the default, if the request fails.', (done) => {
       component.instance().submitFormRequest('2099-13');
       setTimeout(
         () => {
           expect(updateBookStore.called).to.equal(true);
           expect(updateBookStore.getCall(0).args).to.deep.equal([]);
 
+          done();
+        }, 150
+      );
+    });
+
+    it('should set URL to the 404 page, if the request fails.', (done) => {
+      component.instance().submitFormRequest('2099-13');
+      setTimeout(
+        () => {
           expect(updateHistory.called).to.equal(true);
           expect(updateHistory.getCall(0).args).to.deep.equal(['/books-music-dvds/recommendations/staff-picks/404']);
 
@@ -147,18 +156,28 @@ describe('ListSelector', () => {
       );
     });
 
-    it('should update BookStore with the data responsed and set the correct URL, if the request succeeds.', (done) => {
+    it('should update BookStore with the data responsed, if the request succeeds.', (done) => {
       component.instance().submitFormRequest('2017-01');
       setTimeout(
         () => {
           expect(updateBookStore.called).to.equal(true);
           expect(updateBookStore.getCall(0).args).to.deep.equal(
-            [mockBookListResponse.currentPicks]
+            [mockBookListResponse.currentPicks, '2017-01']
           );
 
+          done();
+        }, 150
+      );
+    });
+
+    it('should set the correct URL, if the request succeeds.', (done) => {
+      component.instance().submitFormRequest('2017-01');
+      setTimeout(
+        () => {
           expect(updateHistory.called).to.equal(true);
           expect(updateHistory.getCall(0).args).to.deep.equal(['/books-music-dvds/recommendations/staff-picks/2017-01-01/']);
 
+          // expect the drop down menu fits the current select
           done();
         }, 150
       );

--- a/test/unit/ListSelector.test.js
+++ b/test/unit/ListSelector.test.js
@@ -147,7 +147,7 @@ describe('ListSelector', () => {
     });
 
     it('should set URL to the 404 page, if the request fails.', (done) => {
-      component.instance().submitFormRequest('season', '2099-13');
+      component.instance().submitFormRequest('season', '2099-13-01');
       setTimeout(
         () => {
           expect(updateHistory.called).to.equal(true);
@@ -164,7 +164,7 @@ describe('ListSelector', () => {
         () => {
           expect(updateBookStore.called).to.equal(true);
           expect(updateBookStore.getCall(0).args).to.deep.equal(
-            [mockBookListResponse.currentPicks, '2017-01', 'Adult', "staff-picks"]
+            [mockBookListResponse.currentPicks, '2017-01-01', 'Adult', "staff-picks"]
           );
 
           done();
@@ -173,7 +173,7 @@ describe('ListSelector', () => {
     });
 
     it('should set the correct URL, if the request succeeds.', (done) => {
-      component.instance().submitFormRequest('season', '2017-01');
+      component.instance().submitFormRequest('season', '2017-01-01');
       setTimeout(
         () => {
           expect(updateHistory.called).to.equal(true);

--- a/test/unit/ListSelector.test.js
+++ b/test/unit/ListSelector.test.js
@@ -151,7 +151,9 @@ describe('ListSelector', () => {
       setTimeout(
         () => {
           expect(updateHistory.called).to.equal(true);
-          expect(updateHistory.getCall(0).args).to.deep.equal(['/books-music-dvds/recommendations/staff-picks/404']);
+          expect(updateHistory.getCall(0).args).to.deep.equal(
+            ['/books-music-dvds/recommendations/staff-picks/404']
+          );
 
           done();
         }, 150
@@ -164,7 +166,7 @@ describe('ListSelector', () => {
         () => {
           expect(updateBookStore.called).to.equal(true);
           expect(updateBookStore.getCall(0).args).to.deep.equal(
-            [mockBookListResponse.currentPicks, '2017-01-01', 'Adult', "staff-picks"]
+            [mockBookListResponse.currentPicks, '2017-01-01', 'Adult', 'staff-picks']
           );
 
           done();
@@ -177,7 +179,9 @@ describe('ListSelector', () => {
       setTimeout(
         () => {
           expect(updateHistory.called).to.equal(true);
-          expect(updateHistory.getCall(0).args).to.deep.equal(['/books-music-dvds/recommendations/staff-picks/2017-01-01']);
+          expect(updateHistory.getCall(0).args).to.deep.equal(
+            ['/books-music-dvds/recommendations/staff-picks/2017-01-01']
+          );
 
           done();
         }, 150

--- a/test/unit/ListSelector.test.js
+++ b/test/unit/ListSelector.test.js
@@ -11,18 +11,20 @@ import config from '../../appConfig';
 const fieldsetProps = {
   season: {
     fieldsetName: 'season',
+    currentValue: '2018-01',
     options: [
-      { name: '2018 Winter', value: '2018-01-01' },
-      { name: '2017 Fall', value: '2017-09-01' },
-      { name: '2017 Summer', value: '2017-06-01' },
-      { name: '2017 Spring', value: '2017-04-01' },
+      { name: '2018 Winter', value: '2018-01' },
+      { name: '2017 Fall', value: '2017-09' },
+      { name: '2017 Summer', value: '2017-06' },
+      { name: '2017 Spring', value: '2017-04' },
     ],
   },
   audience: {
     fieldsetName: 'audience',
+    currentValue: 'adult',
     options: [
       { name: 'Adult', value: 'adult' },
-      { name: 'Teen', value: 'teen' },
+      { name: 'Teen', value: 'ya' },
       { name: 'Children', value: 'children' },
     ],
   },
@@ -54,7 +56,7 @@ describe('ListSelector', () => {
     const component = shallow(<ListSelector fieldsetProps={fieldsetProps} />);
 
     before(() => {
-      component.instance().handleChange({ target: { value: '2017-01' } });
+      component.instance().handleChange('season', { target: { value: '2017-01' } });
     });
 
     after(() => {
@@ -106,7 +108,7 @@ describe('ListSelector', () => {
           statusText: 'Undefined error',
           status: 500,
         })
-        .onGet(`${config.baseApiUrl}2017-01`)
+        .onGet(`${config.baseApiUrl}2017-01?audience=adult`)
         .reply(200, mockBookListResponse);
     });
 
@@ -133,7 +135,7 @@ describe('ListSelector', () => {
     // the point where the current test is completed. The mark tells chai it is the time to do the
     // next test.
     it('should set BookStore back to the default, if the request fails.', (done) => {
-      component.instance().submitFormRequest('2099-13');
+      component.instance().submitFormRequest('season', '2099-13');
       setTimeout(
         () => {
           expect(updateBookStore.called).to.equal(true);
@@ -145,7 +147,7 @@ describe('ListSelector', () => {
     });
 
     it('should set URL to the 404 page, if the request fails.', (done) => {
-      component.instance().submitFormRequest('2099-13');
+      component.instance().submitFormRequest('season', '2099-13');
       setTimeout(
         () => {
           expect(updateHistory.called).to.equal(true);
@@ -157,12 +159,12 @@ describe('ListSelector', () => {
     });
 
     it('should update BookStore with the data responsed, if the request succeeds.', (done) => {
-      component.instance().submitFormRequest('2017-01');
+      component.instance().submitFormRequest('season', '2017-01');
       setTimeout(
         () => {
           expect(updateBookStore.called).to.equal(true);
           expect(updateBookStore.getCall(0).args).to.deep.equal(
-            [mockBookListResponse.currentPicks, '2017-01']
+            [mockBookListResponse.currentPicks, '2017-01', 'adult']
           );
 
           done();
@@ -171,13 +173,12 @@ describe('ListSelector', () => {
     });
 
     it('should set the correct URL, if the request succeeds.', (done) => {
-      component.instance().submitFormRequest('2017-01');
+      component.instance().submitFormRequest('season', '2017-01');
       setTimeout(
         () => {
           expect(updateHistory.called).to.equal(true);
           expect(updateHistory.getCall(0).args).to.deep.equal(['/books-music-dvds/recommendations/staff-picks/2017-01-01/']);
 
-          // expect the drop down menu fits the current select
           done();
         }, 150
       );

--- a/test/unit/Main.test.js
+++ b/test/unit/Main.test.js
@@ -173,5 +173,9 @@ describe('Main', () => {
         expect(component.state('picks')).to.eql([]);
       });
     });
+
+    describe('extractAudienceGroup', () => {
+      it('should return specific audience/age group based on the props', () => {});
+    });
   });
 });

--- a/test/unit/Main.test.js
+++ b/test/unit/Main.test.js
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 import React from 'react';
+import sinon from 'sinon';
 import { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
 
@@ -7,15 +8,21 @@ import Main from '../../src/app/components/Application/Main';
 
 const picks = [
   {
-    title: 'first book title',
+    book: {
+      title: 'first book title',
+    },
     tags: ['funny', 'horror'],
   },
   {
-    title: 'second book title',
+    book: {
+      title: 'second book title',
+    },
     tags: ['adventure', 'horror'],
   },
   {
-    title: 'third book title',
+    book: {
+      title: 'third book title',
+    },
     tags: ['graphic-novels', 'funny'],
   },
 ];
@@ -73,7 +80,9 @@ describe('Main', () => {
       it('should return a subset of the picks passed, based on the one selected filter', () => {
         expect(getNewPickSet(picks, ['adventure'])).to.eql([
           {
-            title: 'second book title',
+            book: {
+              title: 'second book title',
+            },
             tags: ['adventure', 'horror'],
           },
         ]);
@@ -82,7 +91,9 @@ describe('Main', () => {
       it('should return a subset of the picks passed, based on the selected filters', () => {
         expect(getNewPickSet(picks, selectedFilters)).to.eql([
           {
-            title: 'third book title',
+            book: {
+              title: 'third book title',
+            },
             tags: ['graphic-novels', 'funny'],
           },
         ]);
@@ -156,6 +167,10 @@ describe('Main', () => {
         clearFilters = component.instance().clearFilters;
       });
 
+      after(() => {
+        component.unmount();
+      });
+
       it('should clear the state', () => {
         component.setState({
           picks,
@@ -175,7 +190,43 @@ describe('Main', () => {
     });
 
     describe('extractAudienceGroup', () => {
-      it('should return specific audience/age group based on the props', () => {});
+      const staffPicksData = {
+        picks: [
+          {
+            ageGroup: 'Adult',
+            book: {
+              title: 'book 01',
+            },
+          },
+          {
+            ageGroup: 'Children',
+            book: {
+              title: 'book 01',
+            },
+          },
+          {
+            ageGroup: 'YA',
+            book: {
+              title: 'book 03',
+            },
+          },
+        ],
+      };
+      const extractAudienceGroup = sinon.spy(Main.prototype, 'extractAudienceGroup');
+      const component = shallow(<Main currentPicks={staffPicksData} currentAudience={'YA'} />);
+
+      before(() => {
+      });
+
+      after(() => {
+        extractAudienceGroup.restore();
+        component.unmount();
+      });
+
+      it('should return specific audience/age group based on the props', () => {
+        expect(extractAudienceGroup.called).to.equal(true);
+        expect(extractAudienceGroup.getCall(0).args).to.deep.equal([staffPicksData.picks, 'YA']);
+      });
     });
   });
 });

--- a/test/unit/Main.test.js
+++ b/test/unit/Main.test.js
@@ -213,19 +213,61 @@ describe('Main', () => {
         ],
       };
       const extractAudienceGroup = sinon.spy(Main.prototype, 'extractAudienceGroup');
-      const component = shallow(<Main currentPicks={staffPicksData} currentAudience={'YA'} />);
-
-      before(() => {
-      });
+      const component = shallow(
+        <Main currentPicks={staffPicksData} currentAudience={'YA'} listType={'staff-picks'} />
+      );
 
       after(() => {
         extractAudienceGroup.restore();
         component.unmount();
       });
 
-      it('should return specific audience/age group based on the props', () => {
-        expect(extractAudienceGroup.called).to.equal(true);
-        expect(extractAudienceGroup.getCall(0).args).to.deep.equal([staffPicksData.picks, 'YA']);
+      it('should be called with the passed down picks, age group, and list tyep as the arguments.',
+        () => {
+          expect(extractAudienceGroup.called).to.equal(true);
+          expect(extractAudienceGroup.getCall(0).args).to.deep.equal(
+            [staffPicksData.picks, 'YA', 'staff-picks']
+          );
+        }
+      );
+
+      it('should return the original list if it is not a staff picks list.', () => {
+        const returnedValue = staffPicksData.picks;
+
+        expect(extractAudienceGroup(staffPicksData.picks, 'YA', 'some-other-list')).to.deep.equal(
+          returnedValue
+        );
+      });
+
+      it('should return an empty array if the passed down list is empty.', () => {
+        const returnedValue = [];
+
+        expect(extractAudienceGroup([], 'YA', 'staff-picks')).to.deep.equal(
+          returnedValue
+        );
+      });
+
+      it('should return an empty array if the passed down age group is not valid.', () => {
+        const returnedValue = [];
+
+        expect(extractAudienceGroup(staffPicksData.picks, 'Toddler', 'staff-picks')).to.deep.equal(
+          returnedValue
+        );
+      });
+
+      it('should return a specific audience/age group based on the props.', () => {
+        const returnedValue = [
+          {
+            ageGroup: 'YA',
+            book: {
+              title: 'book 03',
+            },
+          },
+        ];
+
+        expect(extractAudienceGroup(staffPicksData.picks, 'YA', 'staff-picks')).to.deep.equal(
+          returnedValue
+        );
       });
     });
   });


### PR DESCRIPTION
This PR mainly updates functions in `monthData.js` so now they deal with dynamic param for seasons and query for audience.

Second, it updates the correct URLs (as the ones of current dgx-staff-picks) after a client side or server side request is made. The audience query won't be displayed unless the server side query is made by form submission.

Finally, it display the list with correct audience group. The default is always adult with only season input from the URL, or on the landing page. The user can choose different audience by the dropdown menu, or from submission without JS.