### PR TITLE
Meta tags

### DIFF
--- a/appConfig.js
+++ b/appConfig.js
@@ -55,6 +55,31 @@ const config = {
       { name: 'twitter:image:alt', content: 'Featured title: The Book of Mistakes by ' +
         'Corinna Luyken' },
     ],
+    'staff-picks': [
+      { property: 'og:type', content: 'website' },
+      { property: 'og:site_name', content: 'Staff Picks' },
+      { property: 'og:title', content: 'Staff Picks' },
+      { property: 'og:description', content: 'True stories, tales of courage, historical ' +
+        'romances, edge-of-your-seat thrillers... There is a huge world of books out there. ' +
+        'Our expert staff members pick out their favorites to help you find your next one.' },
+      { property: 'og:url', content: 'https://www.nypl.org/books-music-movies/recommendations' +
+        '/best-books/staff-picks' },
+      { property: 'og:image', content: 'https://www.nypl.org/books-music-movies/recommendations' +
+        '/best-books/src/client/images/shelftalker.4.2.png' },
+      { property: 'og:image:alt', content: 'Featured title: Anathem by Neal Stephenson' },
+      { property: 'og:image:width', content: '335' },
+      { property: 'og:image:height', content: '600' },
+      { name: 'twitter:title', content: 'Staff Picks' },
+      { name: 'twitter:card', content: 'summary_large_image' },
+      { name: 'twitter:site', content: '@nypl' },
+      { name: 'twitter:creator', content: '@nypl' },
+      { name: 'twitter:description', content: 'True stories, tales of courage, historical ' +
+        'romances, edge-of-your-seat thrillers... There is a huge world of books out there. ' +
+        'Our expert staff members pick out their favorites to help you find your next one.' },
+      { name: 'twitter:image', content: 'https://www.nypl.org/books-music-movies/recommendations' +
+        '/best-books/src/client/images/shelftalker.4.2.png' },
+      { name: 'twitter:image:alt', content: 'Featured title: Anathem by Neal Stephenson' },
+    ],
   },
   seasons: {
     Spring: ['March', 'April', 'May'],

--- a/server.js
+++ b/server.js
@@ -81,8 +81,6 @@ app.use('/', (req, res) => {
 
       iso.add(html, alt.flush());
 
-      console.log(pageTitle, metaTags);
-
       res
         .status(200)
         .render('index', {

--- a/server.js
+++ b/server.js
@@ -76,10 +76,12 @@ app.use('/', (req, res) => {
         res.locals.data.metaTags : [];
       const renderedMetaTags = metaTags.map((tag, index) =>
         ReactDOMServer.renderToString(<meta key={index} {...tag} />));
-      const renderedPageTitle = (res.locals.data && res.locals.data.pageTitle) ?
+      const pageTitle = (res.locals.data && res.locals.data.pageTitle) ?
         res.locals.data.pageTitle : '';
 
       iso.add(html, alt.flush());
+
+      console.log(pageTitle, metaTags);
 
       res
         .status(200)
@@ -90,7 +92,7 @@ app.use('/', (req, res) => {
           markup: iso.render(),
           assets: buildAssets,
           webpackPort: WEBPACK_DEV_PORT,
-          pageTitle: renderedPageTitle,
+          pageTitle,
         });
     } else {
       res.status(404).send('Not found');

--- a/src/server/routes/annualData.js
+++ b/src/server/routes/annualData.js
@@ -18,14 +18,15 @@ const nyplApiClientGet = endpoint =>
  */
 function annualCurrentListData(req, res, next) {
   const listOptions = config.annualListOptions;
+  const { type } = req.params;
   let seasonListOptions = [];
   let latestSeason = '';
-  const dataType = utils.getDataType(req.params.type);
+  const dataType = utils.getDataType(type);
 
   nyplApiClientGet(platformConfig.endpoints.annualLists[dataType])
     .then((data) => {
       // Models the options based on the data returned
-      const modeledOptionObject = modelListOptions(data, req.params.type);
+      const modeledOptionObject = modelListOptions(data, type);
 
       seasonListOptions = modeledOptionObject.options;
       latestSeason = modeledOptionObject.latestOption;
@@ -60,8 +61,8 @@ function annualCurrentListData(req, res, next) {
           listOptions,
           currentSeason: latestSeason,
         },
-        pageTitle: '',
-        metaTags: [],
+        pageTitle: config.pageTitle[type],
+        metaTags: config.metaTags[type],
       };
 
       next();
@@ -85,10 +86,11 @@ function annualCurrentListData(req, res, next) {
 function annualListData(req, res, next) {
   const listOptions = config.annualListOptions;
   let seasonListOptions = [];
-  const dataType = utils.getDataType(req.params.type);
+  const { type } = req.params;
+  const dataType = utils.getDataType(type);
 
   // Checks if the URL input fits season's convention
-  const seasonMatches = matchListDate(req.params.time, req.params.type);
+  const seasonMatches = matchListDate(req.params.time, type);
   // Default audience list is the adult list
   let requestedSeason = '';
 
@@ -105,7 +107,7 @@ function annualListData(req, res, next) {
   nyplApiClientGet(platformConfig.endpoints.annualLists[`${dataType}`])
     .then((data) => {
       // Models the options based on the data returned
-      const modeledOptionObject = modelListOptions(data, req.params.type);
+      const modeledOptionObject = modelListOptions(data, type);
 
       seasonListOptions = modeledOptionObject.options;
 
@@ -139,8 +141,8 @@ function annualListData(req, res, next) {
           listOptions,
           currentSeason: requestedSeason,
         },
-        pageTitle: '',
-        metaTags: [],
+        pageTitle: config.pageTitle[type],
+        metaTags: config.metaTags[type],
       };
       next();
     })

--- a/src/server/routes/monthData.js
+++ b/src/server/routes/monthData.js
@@ -6,6 +6,8 @@ import platformConfig from '../../../platformConfig';
 import modelListOptions from '../../app/utils/ModelListOptionsService';
 import { matchListDate } from '../../app/utils/DateService';
 
+const STAFF_PICKS = 'staff-picks';
+
 /* nyplApiClientGet(endpoint)
  * The function that wraps nyplApiClient for GET requests.
  * @param {string} endpoint
@@ -26,7 +28,7 @@ function currentMonthData(req, res, next) {
   nyplApiClientGet(platformConfig.endpoints.allStaffPicksLists)
     .then((data) => {
       // Models the options based on the data returned
-      const modeledOptionObject = modelListOptions(data, 'staff-picks');
+      const modeledOptionObject = modelListOptions(data, STAFF_PICKS);
 
       seasonListOptions = modeledOptionObject.options;
       latestSeason = modeledOptionObject.latestOption;
@@ -52,8 +54,8 @@ function currentMonthData(req, res, next) {
           currentSeason: latestSeason,
           currentAudience: 'Adult',
         },
-        pageTitle: '',
-        metaTags: [],
+        pageTitle: config.pageTitle[STAFF_PICKS],
+        metaTags: config.metaTags[STAFF_PICKS],
       };
 
       next();
@@ -105,7 +107,7 @@ function selectMonthData(req, res, next) {
   nyplApiClientGet(platformConfig.endpoints.allStaffPicksLists)
     .then((data) => {
       // Models the options based on the data returned
-      const modeledOptionObject = modelListOptions(data, 'staff-picks');
+      const modeledOptionObject = modelListOptions(data, STAFF_PICKS);
 
       seasonListOptions = modeledOptionObject.options;
 
@@ -141,8 +143,8 @@ function selectMonthData(req, res, next) {
           currentSeason: requestedSeason,
           currentAudience: audience,
         },
-        pageTitle: '',
-        metaTags: [],
+        pageTitle: config.pageTitle[STAFF_PICKS],
+        metaTags: config.metaTags[STAFF_PICKS],
       };
       next();
     })


### PR DESCRIPTION
This will get and render the correct page title and meta tags (OG and Twitter) on the server side. They are static and do not need to change between year or season.

This PR does NOT include any updates to images or descriptions, but I did copy over the current Staff Picks image and description from the current Staff Picks on Prod (nypl.org/staff-picks).

@courtneymcgee that can be a separate ticket unless if what's here already is fine. This will render the meta tags like so (and note, it's not related to the banner image):
![screen shot 2018-05-10 at 1 19 33 pm](https://user-images.githubusercontent.com/1280564/39883511-0dd43514-5455-11e8-8544-79a9876293a3.png)
