### PR TITLE
Year month and selector changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ client/.DS_Store
 .nyc_output
 package-lock.json
 .env
+log
 
 # Elastic Beanstalk Files
 .elasticbeanstalk/*

--- a/appConfig.js
+++ b/appConfig.js
@@ -160,7 +160,7 @@ const config = {
   },
   annualListOptions: {
     season: {
-      fieldsetName: 'season',
+      fieldsetName: 'year',
       currentValue: '',
       options: [],
     },

--- a/src/app/components/ListSelector/ListSelector.jsx
+++ b/src/app/components/ListSelector/ListSelector.jsx
@@ -131,10 +131,10 @@ class ListSelector extends React.Component {
 
     const listType = fieldsetProps.fieldsetName;
 
-    // Returns eifferent fieldsets based on different list types.
-    // Now we only have season and audience.
-    // Any types aside these two shouldn't be displayed.
-    if (listType === 'season') {
+    // Returns different fieldsets based on different list types.
+    // Now we only have season/year and audience.
+    // Any types aside from these two shouldn't be displayed.
+    if (listType === 'season' || listType === 'year') {
       return (
         <ListFilter
           fieldsetProps={fieldsetProps}

--- a/src/app/utils/DateService.js
+++ b/src/app/utils/DateService.js
@@ -89,6 +89,7 @@ function annualDate(dateStr) {
   }
 
   const annDate = matchListDate(dateStr, 'annual');
+
   if (annDate) {
     year = new Date(annDate[1], '01', '01').getFullYear();
   }

--- a/src/app/utils/DateService.js
+++ b/src/app/utils/DateService.js
@@ -65,7 +65,7 @@ function staffPicksDate(dateStr) {
 
   const d = matchListDate(dateStr);
   const regexMonth = parseInt(d[1], 10) <= 2015 ? d[2] - 1 : d[2];
-  const newDate = new Date(d[1], regexMonth, '01');
+  const newDate = new Date(d[1], regexMonth);
   const year = newDate.getFullYear();
   const month = monthOrSeason(newDate.getMonth(), year);
 

--- a/src/app/utils/DateService.js
+++ b/src/app/utils/DateService.js
@@ -40,7 +40,7 @@ function matchListDate(dateStr, type = 'staff-picks') {
   if (type !== 'staff-picks') {
     pattern = /^(\d{4})$/;
   } else {
-    pattern = /^(\d{4})\-(\d{2})\-(\d{2})$/;
+    pattern = /^(\d{4})\-(\d{2})$/;
   }
 
   const validMatch = dateStr.match(pattern);
@@ -50,7 +50,7 @@ function matchListDate(dateStr, type = 'staff-picks') {
 
 /**
  * staffPicksDate(dateStr)
- * Reads an string date that's specific to the Staff Picks API endpoint, such as "2018-01-01".
+ * Reads an string date that's specific to the Staff Picks API endpoint, such as "2018-01".
  * The string gets parsed to get either the correct month or season, and year.
  * @param {string} dateStr
  * @returns {object}
@@ -65,7 +65,7 @@ function staffPicksDate(dateStr) {
 
   const d = matchListDate(dateStr);
   const regexMonth = parseInt(d[1], 10) <= 2015 ? d[2] - 1 : d[2];
-  const newDate = new Date(d[1], regexMonth, d[3]);
+  const newDate = new Date(d[1], regexMonth, '01');
   const year = newDate.getFullYear();
   const month = monthOrSeason(newDate.getMonth(), year);
 

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -169,6 +169,17 @@ function Utils() {
 
     return !types[type] ? type : types[type];
   };
+
+  /**
+   * toMonthAndYear(match, d1, d2)
+   * Returns first two matches hyphenated for redirecting a three part date
+   * to a two part date in a URL.
+   * @param {object} match
+   * @param {integer} d1
+   * @param {integer} d2
+   * @return {string}
+   */
+  this.toMonthAndYear = (match, d1, d2) => [d1, d2].join('-');
 }
 
 export default new Utils();

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -16,6 +16,7 @@ function Utils() {
   /**
    * createAppHistory
    * Create a history in the browser or server that coincides with react-router.
+   * @return {object}
    */
   this.createAppHistory = () => {
     if (typeof window !== 'undefined') {
@@ -29,7 +30,6 @@ function Utils() {
    * trackPicks(action, label)
    * Track a GA click event, where action and label come from
    * the higher level function call from _trackEvent().
-   *
    * @param {string} action Action for GA event.
    * @param {string} label Label for GA event.
    */
@@ -52,7 +52,6 @@ function Utils() {
   /**
    * getSelectedTags(tagArray, selectedFilters)
    * Return an array of the filters in a pick's tagArray if the selectedFilters is found.
-   *
    * @param {array} tagArray
    * @param {array} selectedFilters
    */
@@ -70,7 +69,6 @@ function Utils() {
   /**
    * getFiltersMapping(filters)
    * Return mapping of filters
-   *
    * @return {Object} filters - A map of id and label key-value pairs of filters
    * @param {array} filters - Array of filters
    */

--- a/src/server/routes/monthData.js
+++ b/src/server/routes/monthData.js
@@ -68,6 +68,18 @@ function currentMonthData(req, res, next) {
     });
 }
 
+/**
+ * Returns first two matches hyphenated for redirecting a three part date
+ * to a two part date in a URL.
+ * @param {object} match
+ * @param {integer} d1
+ * @param {integer} d2
+ * @return {string}
+ */
+function toMonthAndYear(match, d1, d2) {
+  return [d1, d2].join('-');
+}
+
 /* selectMonthData
  * Get a specific month's or season's staff pick list.
 * It calls '/book-lists?type=staff-picks' to get all the available list options first.
@@ -75,9 +87,16 @@ function currentMonthData(req, res, next) {
 function selectMonthData(req, res, next) {
   const listOptions = config.staffPicksListOptions;
   let seasonListOptions = [];
+  const dateRequest = req.params.time;
+
+  // Redirects older three part dates in URLs to the new two part date before validation.
+  if (dateRequest && /^(\d{4})-(\d{2})-(\d{2})$/.test(dateRequest)) {
+    const newPath = req.url.replace(/(\d{4})-(\d{2})-(\d{2})/, toMonthAndYear);
+    return res.redirect(newPath);
+  }
 
   // Checks if the URL input fits season's convention
-  const seasonMatches = matchListDate(req.params.time);
+  const seasonMatches = matchListDate(dateRequest);
   // Default audience list is the adult list
   let audience = 'Adult';
   let isValidAudience = true;
@@ -161,7 +180,15 @@ function selectMonthData(req, res, next) {
  * Gets a specific month's or season's staff pick list on the client side.
  */
 function selectClientMonthData(req, res) {
-  const seasonMatches = matchListDate(req.params.time);
+  const dateRequest = req.params.time;
+  // Redirects older three part dates in URLs to the new two part date before validation.
+  if (dateRequest && /^(\d{4})-(\d{2})-(\d{2})$/.test(dateRequest)) {
+    const newPath = req.url.replace(/(\d{4})-(\d{2})-(\d{2})/, toMonthAndYear);
+    return res.redirect(`${config.baseUrl}${newPath}`);
+  }
+
+  // Checks if the URL input fits season's convention
+  const seasonMatches = matchListDate(dateRequest);
   if (!seasonMatches) {
     logger.error('Status Code: 400, Error Message: Invalid season.');
 

--- a/src/server/routes/monthData.js
+++ b/src/server/routes/monthData.js
@@ -68,18 +68,6 @@ function currentMonthData(req, res, next) {
     });
 }
 
-/**
- * Returns first two matches hyphenated for redirecting a three part date
- * to a two part date in a URL.
- * @param {object} match
- * @param {integer} d1
- * @param {integer} d2
- * @return {string}
- */
-function toMonthAndYear(match, d1, d2) {
-  return [d1, d2].join('-');
-}
-
 /* selectMonthData
  * Get a specific month's or season's staff pick list.
 * It calls '/book-lists?type=staff-picks' to get all the available list options first.
@@ -91,7 +79,7 @@ function selectMonthData(req, res, next) {
 
   // Redirects older three part dates in URLs to the new two part date before validation.
   if (dateRequest && /^(\d{4})-(\d{2})-(\d{2})$/.test(dateRequest)) {
-    const newPath = req.url.replace(/(\d{4})-(\d{2})-(\d{2})/, toMonthAndYear);
+    const newPath = req.url.replace(/(\d{4})-(\d{2})-(\d{2})/, utils.toMonthAndYear);
     return res.redirect(newPath);
   }
 

--- a/test/unit/DateService.test.js
+++ b/test/unit/DateService.test.js
@@ -13,13 +13,13 @@ describe('DateService', () => {
 
     describe('When the passed year is earlier than 2016', () => {
       it('should return the correct month and year.', () => {
-        expect(staffPicksDate('2015-04-01')).to.deep.equal({ month: 'April', year: 2015 });
+        expect(staffPicksDate('2015-04')).to.deep.equal({ month: 'April', year: 2015 });
       });
     });
 
     describe('When the passed year is later than 2016', () => {
       it('should return month value as the season with the correct year.', () => {
-        expect(staffPicksDate('2016-06-01')).to.deep.equal({ month: 'Summer', year: 2016 });
+        expect(staffPicksDate('2016-06')).to.deep.equal({ month: 'Summer', year: 2016 });
       });
     });
   });

--- a/test/unit/ListFilter.test.js
+++ b/test/unit/ListFilter.test.js
@@ -9,21 +9,21 @@ const fieldsetProps = {
   fieldsetName: 'season',
   currentValue: '',
   options: [
-    { name: '2018 Winter', value: '2018-01-01' },
-    { name: '2017 Fall', value: '2017-09-01' },
-    { name: '2017 Summer', value: '2017-06-01' },
-    { name: '2017 Spring', value: '2017-04-01' },
+    { name: '2018 Winter', value: '2018-01' },
+    { name: '2017 Fall', value: '2017-09' },
+    { name: '2017 Summer', value: '2017-06' },
+    { name: '2017 Spring', value: '2017-04' },
   ],
 };
 
 const fieldsetPropsWithCurrentValue = {
   fieldsetName: 'season',
-  currentValue: '2017-04-01',
+  currentValue: '2017-04',
   options: [
-    { name: '2018 Winter', value: '2018-01-01' },
-    { name: '2017 Fall', value: '2017-09-01' },
-    { name: '2017 Summer', value: '2017-06-01' },
-    { name: '2017 Spring', value: '2017-04-01' },
+    { name: '2018 Winter', value: '2018-01' },
+    { name: '2017 Fall', value: '2017-09' },
+    { name: '2017 Summer', value: '2017-06' },
+    { name: '2017 Spring', value: '2017-04' },
   ],
 };
 
@@ -64,13 +64,13 @@ describe('ListFilter', () => {
     it('should be the first option\'s value, if no currentValue in props passed down.', () => {
       component = shallow(<ListFilter fieldsetProps={fieldsetProps} />);
 
-      expect(component.find('select').nodes[0].props.value).to.equal('2018-01-01');
+      expect(component.find('select').nodes[0].props.value).to.equal('2018-01');
     });
 
     it('should be assigned with the props\'s currentValue, if the value exists.', () => {
       component = shallow(<ListFilter fieldsetProps={fieldsetPropsWithCurrentValue} />);
 
-      expect(component.find('select').nodes[0].props.value).to.equal('2017-04-01');
+      expect(component.find('select').nodes[0].props.value).to.equal('2017-04');
     });
   });
 });

--- a/test/unit/ListSelector.test.js
+++ b/test/unit/ListSelector.test.js
@@ -13,10 +13,10 @@ const fieldsetProps = {
     fieldsetName: 'season',
     currentValue: '2018-01',
     options: [
-      { name: '2018 Winter', value: '2018-01-01' },
-      { name: '2017 Fall', value: '2017-09-01' },
-      { name: '2017 Summer', value: '2017-06-01' },
-      { name: '2017 Spring', value: '2017-04-01' },
+      { name: '2018 Winter', value: '2018-01' },
+      { name: '2017 Fall', value: '2017-09' },
+      { name: '2017 Summer', value: '2017-06' },
+      { name: '2017 Spring', value: '2017-04' },
     ],
   },
   audience: {
@@ -100,7 +100,7 @@ describe('ListSelector', () => {
     const component = shallow(<ListSelector fieldsetProps={fieldsetProps} />);
 
     before(() => {
-      component.instance().handleSeasonChange({ target: { value: '2017-01-01' } });
+      component.instance().handleSeasonChange({ target: { value: '2017-01' } });
     });
 
     after(() => {
@@ -119,7 +119,7 @@ describe('ListSelector', () => {
     const updateLocation = sinon.spy(ListSelector.prototype, 'updateLocation');
     const component = shallow(<ListSelector fieldsetProps={fieldsetProps} />);
     const mockBookListResponse = {
-      date: '2017-01-01',
+      date: '2017-01',
       title: 'Winter 2016 Staff Picks',
       picksData: {
         picks: [
@@ -147,12 +147,12 @@ describe('ListSelector', () => {
 
     before(() => {
       mock
-        .onGet(`${config.baseApiUrl}2099-13-01`)
+        .onGet(`${config.baseApiUrl}2099-13`)
         .reply(500, {
           statusText: 'Undefined error',
           status: 500,
         })
-        .onGet(`${config.baseApiUrl}staff-picks/2017-01-01`)
+        .onGet(`${config.baseApiUrl}staff-picks/2017-01`)
         .reply(200, mockBookListResponse);
     });
 
@@ -179,7 +179,7 @@ describe('ListSelector', () => {
     // the point where the current test is completed. The mark tells chai it is the time to do the
     // next test.
     it('should set BookStore back to the default, if the request fails.', (done) => {
-      component.instance().submitFormRequest('season', '2099-13-01');
+      component.instance().submitFormRequest('season', '2099-13');
       setTimeout(
         () => {
           expect(updateBookStore.called).to.equal(true);
@@ -191,7 +191,7 @@ describe('ListSelector', () => {
     });
 
     it('should set URL to the 404 page, if the request fails.', (done) => {
-      component.instance().submitFormRequest('season', '2099-13-01');
+      component.instance().submitFormRequest('season', '2099-13');
       setTimeout(
         () => {
           expect(updateLocation.called).to.equal(true);
@@ -205,12 +205,12 @@ describe('ListSelector', () => {
     });
 
     it('should update BookStore with the data response, if the request succeeds.', (done) => {
-      component.instance().submitFormRequest('2017-01-01');
+      component.instance().submitFormRequest('2017-01');
       setTimeout(
         () => {
           expect(updateBookStore.called).to.equal(true);
           expect(updateBookStore.getCall(0).args).to.deep.equal(
-            [mockBookListResponse, '2017-01-01', [], []]
+            [mockBookListResponse, '2017-01', [], []]
           );
 
           done();
@@ -219,12 +219,12 @@ describe('ListSelector', () => {
     });
 
     it('should set the correct URL, if the request succeeds.', (done) => {
-      component.instance().submitFormRequest('2017-01-01');
+      component.instance().submitFormRequest('2017-01');
       setTimeout(
         () => {
           expect(updateLocation.called).to.equal(true);
           expect(updateLocation.getCall(0).args).to.deep.equal(
-            ['/books-music-movies/recommendations/best-books/staff-picks/2017-01-01']
+            ['/books-music-movies/recommendations/best-books/staff-picks/2017-01']
           );
 
           done();

--- a/test/unit/Main.test.js
+++ b/test/unit/Main.test.js
@@ -155,13 +155,13 @@ describe('Main', () => {
       });
 
       it('should return a date object and default of Adult age', () => {
-        expect(getPicksInfo({ date: '2018-01-01', type: 'staff-picks' })).to.eql({
+        expect(getPicksInfo({ date: '2018-01', type: 'staff-picks' })).to.eql({
           displayDate: { month: 'Winter', year: 2018 }, displayAge: 'Adult',
         });
       });
 
       it('should return a date object with updated age', () => {
-        expect(getPicksInfo({ date: '2017-03-01', type: 'staff-picks' }, 'YA')).to.eql({
+        expect(getPicksInfo({ date: '2017-03', type: 'staff-picks' }, 'YA')).to.eql({
           displayDate: { month: 'Spring', year: 2017 }, displayAge: 'Young Adult',
         });
       });

--- a/test/unit/ModelListOptionsService.test.js
+++ b/test/unit/ModelListOptionsService.test.js
@@ -4,10 +4,10 @@ import { expect } from 'chai';
 import ModelListOptionsService from '../../src/app/utils/ModelListOptionsService';
 
 const mockStaffPicksListOptionsData = [
-  { date: '2015-04-01' },
-  { date: '2017-01-01' },
-  { date: '2017-04-01' },
-  { date: '2018-01-01' },
+  { date: '2015-04' },
+  { date: '2017-01' },
+  { date: '2017-04' },
+  { date: '2018-01' },
 ];
 
 const mockAnnualListOptionsData = [
@@ -18,10 +18,10 @@ const mockAnnualListOptionsData = [
 ];
 
 const mockModeledOptions = [
-  { name: 'Winter 2018', value: '2018-01-01' },
-  { name: 'Spring 2017', value: '2017-04-01' },
-  { name: 'Winter 2017', value: '2017-01-01' },
-  { name: 'April 2015', value: '2015-04-01' },
+  { name: 'Winter 2018', value: '2018-01' },
+  { name: 'Spring 2017', value: '2017-04' },
+  { name: 'Winter 2017', value: '2017-01' },
+  { name: 'April 2015', value: '2015-04' },
 ];
 
 const mockModeledOptionsNotStaffPicks = [
@@ -59,7 +59,7 @@ describe('ModelListOptionsService', () => {
   describe('When there is valid data and the list type is "staff-picks"', () => {
     it('should return the modeled options and "latestOption" equals the first option value.', () => {
       expect(ModelListOptionsService(mockStaffPicksListOptionsData, 'staff-picks')).to.deep.equal(
-        { options: mockModeledOptions, latestOption: '2018-01-01' });
+        { options: mockModeledOptions, latestOption: '2018-01' });
     });
   });
 });


### PR DESCRIPTION
These help to resolve issues #200 and #201. #200 is a simple lable change for the annual lists for Sidebar dropdowns. Should display 'Year' instead of 'Season.'

Changes for issue #201 requires coordination in updating the metadata for lists on the ingester side. Once the year-month pattern for lists is available in the API, the direct links and redirects should work. 

To test, start your local instance using APP_ENV=production. The new pattern is deployed there for staff-picks lists. There are 2 lists there that you can use to test the code changes within this PR.