### PR TITLE
Adding additional check for hash linking for annual lists.

### DIFF
--- a/src/app/components/Sidebar/Sidebar.jsx
+++ b/src/app/components/Sidebar/Sidebar.jsx
@@ -23,7 +23,7 @@ const Sidebar = (props) => {
     listOptions.season.currentValue = data.currentSeason;
     listOptions.type = data.type;
 
-    if (data.currentAudience) {
+    if (data.currentAudience && listOptions.type === 'staff-picks') {
       listOptions.audience.currentValue = data.currentAudience;
     }
 


### PR DESCRIPTION
When trying to link to an individual title in an annual list I get this error:

![screen shot 2018-05-16 at 2 01 03 pm](https://user-images.githubusercontent.com/1280564/40134880-aeba3f12-5911-11e8-944c-761f068e5106.png)

This fixes it by making sure that we are updating the current audience option only for staff picks.

Yep, we didn't link to previous annual list's individuals picks, but this is just a precaution.