### PR TITLE
Updated styles to filter buttons so the x svg icon won't overlay the …

### DIFF
--- a/src/app/components/BookFilters/Filter.jsx
+++ b/src/app/components/BookFilters/Filter.jsx
@@ -93,7 +93,7 @@ class Filter extends React.Component {
           aria-label={arialLabel}
           disabled={this.props.disabled}
         >
-          {icon}{filter.label}
+          {icon}<span>{filter.label}</span>
         </button>
       </li>
     );

--- a/src/client/styles/components/_filter.scss
+++ b/src/client/styles/components/_filter.scss
@@ -32,11 +32,17 @@ li.filter-item {
       position: absolute;
       top: 50%;
       left: 3.5%;
+      display: inline-block;
       @include transform(translate(0, -50%));
 
       @include min-screen($mobile-breakpoint) {
         left: 2%;
       }
+    }
+
+    span {
+      display: inline-block;
+      width: 8rem;
     }
 
     &:disabled {


### PR DESCRIPTION
This PR adds the width and display style for the texts in the filter buttons. This help avoid the "X" icon overlaying on the texts. However, because of the less width, some one line texts will break into two lines.

![screen shot 2018-05-17 at 4 47 18 pm](https://user-images.githubusercontent.com/3506922/40203109-36f516d2-59f2-11e8-9849-106e97a65d29.png)


![screen shot 2018-05-17 at 4 47 26 pm](https://user-images.githubusercontent.com/3506922/40203115-3d72db98-59f2-11e8-90e4-1cc081092ef1.png)
