### PR TITLE
Added the styles to stop IE 11 rendering its default styles for dropd…

### DIFF
--- a/src/client/styles/components/_sidebar.scss
+++ b/src/client/styles/components/_sidebar.scss
@@ -67,6 +67,9 @@
         width: calc(100% - 100px);
       }
     }
+    select::-ms-expand {
+      display: none;
+    }
   }
   a.back-link {
     text-decoration: none;


### PR DESCRIPTION
This PR adds a style rule to stop IE 11 rendering its default dropdown menu styles. It was tested on the IE at the computer behind Greg K.