### PR TITLE
Updated the way in CSS and HTML to hide the elements when JS is enabl…

### DIFF
--- a/src/app/components/Book/Book.jsx
+++ b/src/app/components/Book/Book.jsx
@@ -117,11 +117,12 @@ const Book = ({ pick, isJsEnabled, displayType }) => {
   const renderTags = (tags, jsEnabled) => {
     const tagsMarkup = !_isEmpty(tags) ?
       tags.map((tag, i) => <li key={i}>{tag}{i !== (tags.length - 1) ? ',' : ''}</li>) : null;
-    const hiddenClass = jsEnabled ? 'visuallyHidden js' : 'no-js';
+    const hiddenClass = jsEnabled ? 'js' : 'no-js';
+    const htmlHidden = jsEnabled;
     const tagsWrapperMarkup = <ul>{tagsMarkup}</ul>;
 
     return (tagsWrapperMarkup) ?
-      (<div className={`book-item-tags ${hiddenClass}`}>
+      (<div className={`book-item-tags ${hiddenClass}`} hidden={htmlHidden}>
         <span>Tags: </span>
           {tagsWrapperMarkup}
       </div>) : null;

--- a/src/app/components/ListSelector/ListSelector.jsx
+++ b/src/app/components/ListSelector/ListSelector.jsx
@@ -170,7 +170,8 @@ class ListSelector extends React.Component {
 
   render() {
     const isJsEnabled = this.props.isJsEnabled;
-    const hiddenClass = (isJsEnabled) ? 'visuallyHidden' : 'no-js';
+    const hiddenClass = (isJsEnabled) ? 'js' : 'no-js';
+    const htmlHidden = isJsEnabled;
 
     return (
       <form action={`${config.baseApiUrl}post`} method="post">
@@ -183,6 +184,7 @@ class ListSelector extends React.Component {
           className={hiddenClass}
         />
         <input
+          hidden={htmlHidden}
           type="submit"
           value="Select List"
           className={hiddenClass}

--- a/src/client/styles/components/_bookItem.scss
+++ b/src/client/styles/components/_bookItem.scss
@@ -235,6 +235,7 @@ $book-card-largescreen-gutter: 3.5%;
       -moz-animation: none;
       -o-animation: none;
       animation: none;
+      display: none;
     }
 
     &.no-js {

--- a/src/client/styles/components/_sidebar.scss
+++ b/src/client/styles/components/_sidebar.scss
@@ -45,6 +45,10 @@
     select::-ms-expand {
       display: none;
     }
+
+    .js {
+      display: none;
+    }
   }
 
   /* Set up fade-in animation for submit button, so that before we detect JS on the browser, */

--- a/test/unit/Book.test.js
+++ b/test/unit/Book.test.js
@@ -148,11 +148,11 @@ describe('Book Component', () => {
       expect(tags.find('ul').length).to.equal(1);
     });
 
-    it('should render the pick tags with a visuallyHidden class when JavaScript is enabled', () => {
+    it('should render the pick tags with the class "js" when JavaScript is enabled', () => {
       const tags = component.find('.book-item-tags');
 
       expect(tags.length).to.equal(1);
-      expect(tags.hasClass('visuallyHidden')).to.equal(true);
+      expect(tags.hasClass('js')).to.equal(true);
     });
 
     it('should render each tag to be an <li>.', () => {

--- a/test/unit/ListSelector.test.js
+++ b/test/unit/ListSelector.test.js
@@ -51,11 +51,11 @@ describe('ListSelector', () => {
       }
     );
 
-    it('should render <input> with the class "visuallyHidden" if its props "isJsEnabled" is true.',
+    it('should render <input> with the class "js" if its props "isJsEnabled" is true.',
       () => {
         component.setProps({ isJsEnabled: true });
         expect(component.find('input').length).to.equal(2);
-        expect(component.find('input').node.props.className).to.equal('visuallyHidden');
+        expect(component.find('input').node.props.className).to.equal('js');
       }
     );
   });


### PR DESCRIPTION
This PR updates the changes for hiding elements based on different conditions.
Please see the ticket https://jira.nypl.org/browse/WWW-289
Willa has updated the notes on the description. There should be two elements we need to update.

The submit button for list selector
The tags for each book item
 The goal is to prevent screen readers to read these elements when they are hidden while JS is enabled. The method for implementing follows the WCAG suggestions here,

https://developer.paciellogroup.com/blog/2012/05/html5-accessibility-chops-hidden-and-aria-hidden/
Please see the section of `Hiding content from all users`

Can be tested on dev now
https://dev-www.nypl.org/books-music-movies/recommendations/best-books