### PR TITLE
Add slash redirect; fix for js assets path

### DIFF
--- a/server.js
+++ b/server.js
@@ -55,14 +55,14 @@ nyplApiClient();
 app.use('/', expressRoutes);
 
 // Handle trailing slash
-// app.use((req, res, next) => {
-//   const hasSlash = /\?[^]*\//.test(req.url);
-//   if (req.url.substr(-1) === '/' && req.url.length > 1 && !hasSlash) {
-//     res.redirect(301, req.url.slice(0, -1));
-//   } else {
-//     next();
-//   }
-// });
+app.use((req, res, next) => {
+  const hasSlash = /\?[^]*\//.test(req.url);
+  if (req.url.substr(-1) === '/' && req.url.length > 1 && !hasSlash) {
+    res.redirect(301, req.url.slice(0, -1));
+  } else {
+    next();
+  }
+});
 
 // after get the path
 app.use('/', (req, res) => {

--- a/src/server/views/index.ejs
+++ b/src/server/views/index.ejs
@@ -26,7 +26,7 @@
     </script>
 
   <% if (isProduction) { %>
-    <script async src="dist/<%= assets.app.js %>"></script>
+    <script async src="<%= baseUrl %>/dist/<%= assets.app.js %>"></script>
   <% } else { %>
     <script src="http://localhost:<%= webpackPort %>/bundle.js"></script>
   <% } %>


### PR DESCRIPTION
Uncomments the server.js section for re-routing best-books/ to best-books.

Adds baseUrl to the <script> tag for js assets in index.ejs for non-local environments.