### PR TITLE
Updated props types.

### DIFF
--- a/src/app/components/Sidebar/Sidebar.jsx
+++ b/src/app/components/Sidebar/Sidebar.jsx
@@ -76,7 +76,8 @@ Sidebar.propTypes = {
   clearFilters: PropTypes.func,
   isJsEnabled: PropTypes.bool,
   listOptions: PropTypes.object,
-  selectedFilters: PropTypes.arrayOf(PropTypes.object),
+  selectedFilters: PropTypes.arrayOf(PropTypes.string),
+  type: PropTypes.string,
 };
 
 Sidebar.defaultProps = {
@@ -87,6 +88,7 @@ Sidebar.defaultProps = {
   isJsEnabled: false,
   listOptions: {},
   selectedFilters: [],
+  type: '',
 };
 
 export default Sidebar;


### PR DESCRIPTION
This PR fixes the warning at the browser's console we will see if we select a filter button for the first time. The warning indicates an incorrect props type. Here is the warning.

```
Warning: Failed prop type: Invalid prop `selectedFilters[0]` of type `string` supplied to `Sidebar`, expected `object`.
    in Sidebar (created by Main)
    in Main (created by RouterContext)
    in div (created by App)
    in main (created by App)
    in div (created by App)
    in App (created by RouterContext)
    in RouterContext (created by Router)
    in Router
```
