### PR TITLE
404, about, and title changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "history": "3.3.0",
     "iso": "5.2.0",
     "node-sass": "3.8.0",
+    "pluralize": "7.0.0",
     "prop-types": "15.5.10",
     "react": "15.5.4",
     "react-dom": "15.5.4",

--- a/src/app/components/About/About.jsx
+++ b/src/app/components/About/About.jsx
@@ -43,8 +43,8 @@ class About extends React.Component {
     return (
       <div className="about nypl-row">
         <h2>Additional Information</h2>
-        <p>Many of these titles are available in formats for&nbsp;
-          <a href={aboutUrls.print}>patrons with print disabilities.</a>
+        <p>Many of these titles are available in&nbsp;
+          <a href={aboutUrls.print}>formats for patrons with print disabilities.</a>
         </p>
         {aboutBestBooksLink}
         <ul>

--- a/src/app/components/Error404Page/Error404Page.jsx
+++ b/src/app/components/Error404Page/Error404Page.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import config from '../../../../appConfig';
 
 const Error404Page = () => (
   <div className="error-container">
@@ -8,7 +9,7 @@ const Error404Page = () => (
     </p>
     <p>
       Ready to discover your next great read? Browse and filter our&nbsp;
-      <a href="/books-music-movies/recommendations/best-books/staff-picks">
+      <a aria-label="Browse and filter our Staff Picks" href={`${config.baseUrl}/staff-picks`}>
         Staff Picks.
       </a>
     </p>

--- a/src/app/components/Error404Page/Error404Page.jsx
+++ b/src/app/components/Error404Page/Error404Page.jsx
@@ -15,7 +15,7 @@ const Error404Page = () => (
     </p>
     <p>
       Need help or have a question?&nbsp;
-      <a href="/get-help/contact-us">
+      <a href="https://www.nypl.org/get-help/contact-us">
         Contact us.
       </a>
     </p>

--- a/src/app/components/Error404Page/Error404Page.jsx
+++ b/src/app/components/Error404Page/Error404Page.jsx
@@ -7,8 +7,14 @@ const Error404Page = () => (
       We’re sorry. The page you were looking for doesn’t exist.
     </p>
     <p>
+      Ready to discover your next great read? Browse and filter our&nbsp;
+      <a href="/books-music-movies/recommendations/best-books/staff-picks">
+        Staff Picks.
+      </a>
+    </p>
+    <p>
       Need help or have a question?&nbsp;
-      <a href="https://www.nypl.org/get-help/contact-us">
+      <a href="/get-help/contact-us">
         Contact us.
       </a>
     </p>

--- a/src/app/components/ListTitle/ListTitle.jsx
+++ b/src/app/components/ListTitle/ListTitle.jsx
@@ -4,7 +4,8 @@ import utils from '../../utils/utils';
 
 const ListTitle = (props) => {
   const { displayDate = {}, displayAge } = props.displayInfo;
-  const booksfound = `${props.picksCount} Book${props.picksCount === 1 ? '' : 's'} Found`;
+  const booksCount = utils.makePlural('Book', props.picksCount, true);
+  const booksFound = `${booksCount} Found`;
   const idPrefix = props.idPrefix ? `${props.idPrefix}-` : '';
 
   // General check to see if the year is available.
@@ -13,7 +14,7 @@ const ListTitle = (props) => {
   }
 
   const isStaffPicks = (props.displayType === 'staff-picks');
-  const ageGroup = utils.makeAgeGroupPlural(displayAge);
+  const ageGroup = utils.makePlural(displayAge);
   const content = isStaffPicks ?
     `${displayDate.month} ${displayDate.year} Picks for ${ageGroup}` :
     `${displayDate.year} Picks`;
@@ -26,7 +27,7 @@ const ListTitle = (props) => {
   return (
     <h2 id={`${idPrefix}list-title`} tabIndex="0">
       {content}
-      <span className="pick-count">{booksfound}</span>
+      <span className="pick-count">{booksFound}</span>
     </h2>
   );
 };

--- a/src/app/components/ListTitle/ListTitle.jsx
+++ b/src/app/components/ListTitle/ListTitle.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import utils from '../../utils/utils';
 
 const ListTitle = (props) => {
   const { displayDate = {}, displayAge } = props.displayInfo;
@@ -12,8 +13,9 @@ const ListTitle = (props) => {
   }
 
   const isStaffPicks = (props.displayType === 'staff-picks');
+  const ageGroup = utils.makeAgeGroupPlural(displayAge);
   const content = isStaffPicks ?
-    `${displayDate.month} ${displayDate.year} Picks for ${displayAge}` :
+    `${displayDate.month} ${displayDate.year} Picks for ${ageGroup}` :
     `${displayDate.year} Picks`;
 
   // If it's staff picks and we don't have the following data then return null;

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -183,23 +183,7 @@ function Utils() {
   this.toMonthAndYear = (match, d1, d2) => [d1, d2].join('-');
 
   /**
-   * makeAgeGroupPlural(word)
-   * Simply return an appended 's' for the plural form.
-   * @param {string} ageGroup
-   * @return {string|null}
-   */
-  this.makeAgeGroupPlural = (ageGroup) => {
-    let plural;
-    // If the ageGroup is not already plural, make it so.
-    if (typeof ageGroup === 'string' && ageGroup.toLowerCase() !== 'children') {
-      plural = `${ageGroup}s`;
-    } else {
-      plural = ageGroup;
-    }
-    return plural;
-  };
-
-  /**
+   * makePlural(word, count, inclusive)
    * Use the pluralize package to make a word plural based on predefined rules.
    * @param {string} word
    * @param {integer} count

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -12,7 +12,6 @@ import {
   createMemoryHistory,
 } from 'history';
 import pluralize from 'pluralize';
-import logger from '../../../logger';
 
 function Utils() {
   /**
@@ -209,7 +208,6 @@ function Utils() {
    */
   this.makePlural = (word, count, inclusive) => {
     if (typeof word !== 'string') {
-      logger.info('Word passed to pluralize function is not a string.');
       return word;
     }
     return pluralize(word, count, inclusive);

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -11,6 +11,8 @@ import {
   useQueries,
   createMemoryHistory,
 } from 'history';
+import pluralize from 'pluralize';
+import logger from '../../../logger';
 
 function Utils() {
   /**
@@ -185,17 +187,32 @@ function Utils() {
    * makeAgeGroupPlural(word)
    * Simply return an appended 's' for the plural form.
    * @param {string} ageGroup
-   * @return {string}
+   * @return {string|null}
    */
   this.makeAgeGroupPlural = (ageGroup) => {
     let plural;
     // If the ageGroup is not already plural, make it so.
-    if (ageGroup.toLowerCase() !== 'children') {
+    if (typeof ageGroup === 'string' && ageGroup.toLowerCase() !== 'children') {
       plural = `${ageGroup}s`;
     } else {
       plural = ageGroup;
     }
     return plural;
+  };
+
+  /**
+   * Use the pluralize package to make a word plural based on predefined rules.
+   * @param {string} word
+   * @param {integer} count
+   * @param {boolean} inclusive
+   * @return {string}
+   */
+  this.makePlural = (word, count, inclusive) => {
+    if (typeof word !== 'string') {
+      logger.info('Word passed to pluralize function is not a string.');
+      return word;
+    }
+    return pluralize(word, count, inclusive);
   };
 }
 

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -180,6 +180,23 @@ function Utils() {
    * @return {string}
    */
   this.toMonthAndYear = (match, d1, d2) => [d1, d2].join('-');
+
+  /**
+   * makeAgeGroupPlural(word)
+   * Simply return an appended 's' for the plural form.
+   * @param {string} ageGroup
+   * @return {string}
+   */
+  this.makeAgeGroupPlural = (ageGroup) => {
+    let plural;
+    // If the ageGroup is not already plural, make it so.
+    if (ageGroup.toLowerCase() !== 'children') {
+      plural = `${ageGroup}s`;
+    } else {
+      plural = ageGroup;
+    }
+    return plural;
+  };
 }
 
 export default new Utils();

--- a/src/client/styles/components/_topHeading.scss
+++ b/src/client/styles/components/_topHeading.scss
@@ -29,12 +29,13 @@
     }
 
     @include min-screen($mobile-breakpoint) {
-      font-size: 1.6rem;
+      font-size: 1.5rem;
       margin: 10px 0;
+      letter-spacing: -0.3px;
 
       span {
         font-size: 1rem;
-        margin: 0 10px;
+        margin: 0 6px;
         display: inline-block;
       }
     }

--- a/test/unit/About.test.js
+++ b/test/unit/About.test.js
@@ -32,7 +32,7 @@ describe('About', () => {
     it('should have one link to the accessible print editions of the titles', () => {
       const printDisabilityLink = component.find('a').at(0);
 
-      expect(printDisabilityLink.text()).to.equal('patrons with print disabilities.');
+      expect(printDisabilityLink.text()).to.equal('formats for patrons with print disabilities.');
       expect(printDisabilityLink.prop('href'))
         .to.equal('https://www.nypl.org/accessibility/print-disabilities');
     });

--- a/test/unit/Error404Page.test.js
+++ b/test/unit/Error404Page.test.js
@@ -23,24 +23,35 @@ describe('Error404Page', () => {
       expect(title.text()).to.equal('404 | Not Found');
     });
 
-    it('should have two <p>s with correct contents.', () => {
+    it('should have three <p>s with correct contents.', () => {
       const descriptionParagraphs = component.find('p');
 
-      expect(descriptionParagraphs.length).to.equal(2);
+      expect(descriptionParagraphs.length).to.equal(3);
       expect(descriptionParagraphs.at(0).text()).to.equal(
         'We’re sorry. The page you were looking for doesn’t exist.'
       );
       expect(descriptionParagraphs.at(1).text()).to.equal(
+        'Ready to discover your next great read? Browse and filter our Staff Picks.'
+      );
+      expect(descriptionParagraphs.at(2).text()).to.equal(
         'Need help or have a question? Contact us.'
       );
+    });
+
+    it('should have a link to "Staff Picks".', () => {
+      const askNyplLink = component.find('a');
+
+      expect(askNyplLink.length).to.equal(2);
+      expect(askNyplLink.nodes[0].props.href).to.equal('/books-music-movies/recommendations/best-books/staff-picks');
+      expect(askNyplLink.nodes[0].props.children).to.equal('Staff Picks.');
     });
 
     it('should have a link to "Ask NYPL".', () => {
       const askNyplLink = component.find('a');
 
-      expect(askNyplLink.length).to.equal(1);
-      expect(askNyplLink.node.props.href).to.equal('https://www.nypl.org/get-help/contact-us');
-      expect(askNyplLink.text()).to.equal('Contact us.');
+      expect(askNyplLink.length).to.equal(2);
+      expect(askNyplLink.nodes[1].props.href).to.equal('/get-help/contact-us');
+      expect(askNyplLink.nodes[1].props.children).to.equal('Contact us.');
     });
   });
 });

--- a/test/unit/Error404Page.test.js
+++ b/test/unit/Error404Page.test.js
@@ -51,7 +51,7 @@ describe('Error404Page', () => {
       const askNyplLink = component.find('a');
 
       expect(askNyplLink.length).to.equal(2);
-      expect(askNyplLink.nodes[1].props.href).to.equal('/get-help/contact-us');
+      expect(askNyplLink.nodes[1].props.href).to.equal('https://www.nypl.org/get-help/contact-us');
       expect(askNyplLink.nodes[1].props.children).to.equal('Contact us.');
     });
   });

--- a/test/unit/Error404Page.test.js
+++ b/test/unit/Error404Page.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import Error404Page from '../../src/app/components/Error404Page/Error404Page';
+import config from '../../appConfig';
 
 describe('Error404Page', () => {
   describe('Default', () => {
@@ -42,7 +43,7 @@ describe('Error404Page', () => {
       const askNyplLink = component.find('a');
 
       expect(askNyplLink.length).to.equal(2);
-      expect(askNyplLink.nodes[0].props.href).to.equal('/books-music-movies/recommendations/best-books/staff-picks');
+      expect(askNyplLink.nodes[0].props.href).to.equal(`${config.baseUrl}/staff-picks`);
       expect(askNyplLink.nodes[0].props.children).to.equal('Staff Picks.');
     });
 

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -222,4 +222,15 @@ describe('Utils functions', () => {
       }
     );
   });
+
+  describe('makeAgeGroupPlural', () => {
+    it('should add an `s` to the end of the given word', () => {
+      expect(utils.makeAgeGroupPlural('Adult')).to.eql('Adults');
+      expect(utils.makeAgeGroupPlural('Young Adult')).to.eql('Young Adults');
+      expect(utils.makeAgeGroupPlural('cat')).to.eql('cats');
+    });
+    it('should ignore children which is already plural', () => {
+      expect(utils.makeAgeGroupPlural('Children')).to.eql('Children');
+    });
+  });
 });

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -223,14 +223,18 @@ describe('Utils functions', () => {
     );
   });
 
-  describe('makeAgeGroupPlural', () => {
-    it('should add an `s` to the end of the given word', () => {
-      expect(utils.makeAgeGroupPlural('Adult')).to.eql('Adults');
-      expect(utils.makeAgeGroupPlural('Young Adult')).to.eql('Young Adults');
-      expect(utils.makeAgeGroupPlural('cat')).to.eql('cats');
+  describe('makePlural', () => {
+    it('should return given value when not a string', () => {
+      expect(utils.makePlural(123)).to.eql(123);
+      expect(utils.makePlural([123, 456])).to.eql([123, 456]);
     });
-    it('should ignore children which is already plural', () => {
-      expect(utils.makeAgeGroupPlural('Children')).to.eql('Children');
+    it('should return the plural form of the given word', () => {
+      expect(utils.makePlural('Adult')).to.eql('Adults');
+      expect(utils.makePlural('Young Adult')).to.eql('Young Adults');
+      expect(utils.makePlural('Child')).to.eql('Children');
+    });
+    it('should return children which is already plural', () => {
+      expect(utils.makePlural('Children')).to.eql('Children');
     });
   });
 });


### PR DESCRIPTION
Corresponds to the adjustments requested as part of https://jira.nypl.org/browse/WWW-317

* Adds line with link to Staff Picks on the 404 page template
* Includes more text in the About page link to print formats
* Updates titles to use `Adults` and `Young Adults` plural forms
** was necessary to add some CSS to adjust for longer titles so the # found would not wrap
** see: http://localhost:3001/books-music-movies/recommendations/best-books/staff-picks/2015-09?audience=YA
** reset _top_heading.scss `h2#list-title` to use the default `font-size: 1.6em` and remove `letter-spacing: -0.3px` in order to trigger the wrapping
** wrapping occurs on lists for Young Adults with Summer, September, October, November in the title.
** CSS change fixes for the longest case of September