### PR TITLE
Small CSS override to the footer list item.

### DIFF
--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -50,3 +50,8 @@ body {
 li {
   list-style: none;
 }
+
+// Small override to a normalize rule
+.footer-content .socialMedia li {
+  margin-left: 5;
+}

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -69,4 +69,10 @@ li {
   .copyright p {
     max-width: 100%;
   }
+
+  &-content {
+    @include min-screen(768px) {
+      left: auto;
+    }
+  }
 }

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -51,7 +51,8 @@ li {
   list-style: none;
 }
 
-// Small override to a normalize rule
+// Small override to a normalize rule which mess up the layout for
+// the footer in the mobile and tablet viewports.
 .footer {
   .socialMedia li {
     margin-left: 0;

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -52,6 +52,20 @@ li {
 }
 
 // Small override to a normalize rule
-.footer-content .socialMedia li {
-  margin-left: 0;
+.footer {
+  .socialMedia li {
+    margin-left: 0;
+  }
+
+  .footerLinks {
+    width: 81%;
+
+    @include min-screen(768px) {
+      width: 100%;
+    }
+  }
+
+  .copyright p {
+    max-width: 100%;
+  }
 }

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -53,5 +53,5 @@ li {
 
 // Small override to a normalize rule
 .footer-content .socialMedia li {
-  margin-left: 5;
+  margin-left: 0;
 }


### PR DESCRIPTION
Normalize screws up the footer social media icons only on this app so I made this PR in the repo instead of the footer package.

dev: http://staff-picks-development.us-east-1.elasticbeanstalk.com/books-music-movies/recommendations/best-books/staff-picks