### PR TITLE
Adjustments for 404 and About components

### DIFF
--- a/src/app/components/About/About.jsx
+++ b/src/app/components/About/About.jsx
@@ -43,8 +43,10 @@ class About extends React.Component {
     return (
       <div className="about nypl-row">
         <h2>Additional Information</h2>
-        <p>Many of these titles are available in&nbsp;
-          <a href={aboutUrls.print}>formats for patrons with print disabilities.</a>
+        <p>Many of these titles are available in audio, large print, and braille formats.&nbsp;
+          <a href={aboutUrls.print}>Learn more about library materials and services for
+            patrons with print disabilities.
+          </a>
         </p>
         {aboutBestBooksLink}
         <ul>

--- a/src/app/components/Error404Page/Error404Page.jsx
+++ b/src/app/components/Error404Page/Error404Page.jsx
@@ -9,7 +9,7 @@ const Error404Page = () => (
     </p>
     <p>
       Ready to discover your next great read? Browse and filter our&nbsp;
-      <a aria-label="Browse and filter our Staff Picks" href={`${config.baseUrl}/staff-picks`}>
+      <a href={`${config.baseUrl}/staff-picks`}>
         Staff Picks.
       </a>
     </p>

--- a/src/client/styles/components/_topHeading.scss
+++ b/src/client/styles/components/_topHeading.scss
@@ -29,13 +29,13 @@
     }
 
     @include min-screen($mobile-breakpoint) {
-      font-size: 1.5rem;
+      font-size: 1.6rem;
       margin: 10px 0;
       letter-spacing: -0.3px;
 
       span {
         font-size: 1rem;
-        margin: 0 6px;
+        margin: 0 10px;
         display: inline-block;
       }
     }

--- a/test/unit/About.test.js
+++ b/test/unit/About.test.js
@@ -32,7 +32,7 @@ describe('About', () => {
     it('should have one link to the accessible print editions of the titles', () => {
       const printDisabilityLink = component.find('a').at(0);
 
-      expect(printDisabilityLink.text()).to.equal('formats for patrons with print disabilities.');
+      expect(printDisabilityLink.text()).to.equal('Learn more about library materials and services for patrons with print disabilities.');
       expect(printDisabilityLink.prop('href'))
         .to.equal('https://www.nypl.org/accessibility/print-disabilities');
     });


### PR DESCRIPTION
* Reverted a change to the scss to avoid wrapping the "Books Found" portion on longer titles as per Ricardo's recommendation
* Removed the aria-label added to the 404 page line linking back to the Staff Picks main page
* Updated the text for additional information in the About.jsx component as per copy changes in [WWW-299](https://jira.nypl.org/browse/WWW-299)