### PR TITLE
Updated header to 2.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGELOG
 
+### 4.0.2
+> Update the header component to 2.4.9.
+
 ### 4.0.1
 > Updating @nypl/dgx-react-footer version to 0.5.0 and @nypl/dgx-header-component to 2.4.8.
 > Updating 404 page content to include a link back to /staff-picks.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "staff-picks",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "NYPL Staff Picks",
   "main": "index.js",
   "scripts": {
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@nypl/design-toolkit": "0.1.27",
-    "@nypl/dgx-header-component": "2.4.8",
+    "@nypl/dgx-header-component": "2.4.9",
     "@nypl/dgx-react-footer": "0.5.0",
     "@nypl/dgx-svg-icons": "0.2.5",
     "@nypl/nypl-data-api-client": "0.2.5",


### PR DESCRIPTION
This PR just updates the header to 2.4.9. Can be reviewed on dev
https://dev-www.nypl.org/books-music-movies/recommendations/best-books/staff-picks

The main change should be the visible focus outline styles. It should be dark blue color with shadows
as the screenshot shows
![screen shot 2018-06-25 at 2 29 36 pm](https://user-images.githubusercontent.com/3506922/41868513-47d0efac-7884-11e8-9f52-e340287cfb18.png)
