### PR TITLE
Add check for custom heroImageUrl on list page

### DIFF
--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -52,6 +52,11 @@ class App extends React.Component {
     // Check if the params type is included in valid data set
     if (type && _allKeys(config.heroData).includes(type)) {
       heroData = config.heroData[type];
+      // If currently displayed list has a custom `heroImageUrl`, override
+      // the default:
+      heroData.heroImageUrl = this.state.picksData.heroImageUrl ?
+        this.state.picksData.heroImageUrl
+        : config.heroData[type].heroImageUrl;
       isStaffPicksHero = type === 'staffPicks';
       heroDOM = <Hero heroData={heroData} isStaffPicksHero={isStaffPicksHero} />;
     }


### PR DESCRIPTION
Leverage existing `heroImageUrl` property in list api to display custom
hero image if set. Defaults to baked-in 2017 hero images.