### PR TITLE
RENO-1153-update-dgx-react-footer-to-0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## CHANGELOG
 
 ### 4.0.13
+> Updating @nypl/dgx-react-footer to 0.5.4.
+
+### 4.0.13
 > Updating @nypl/dgx-header-component to 2.6.0
 
 ### 4.0.12

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![devDependencies Status](https://david-dm.org/nypl/staff-picks/dev-status.svg)](https://david-dm.org/nypl/staff-picks?type=dev)
 
 ### Version
-> v4.0.13
+> v4.0.14
 
 ## Technology
 * Universal React

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "staff-picks",
-  "version": "4.0.13",
+  "version": "4.0.14",
   "description": "NYPL Staff Picks",
   "main": "index.js",
   "scripts": {
@@ -47,7 +47,7 @@
   "dependencies": {
     "@nypl/design-toolkit": "0.1.27",
     "@nypl/dgx-header-component": "2.6.0",
-    "@nypl/dgx-react-footer": "0.5.2",
+    "@nypl/dgx-react-footer": "0.5.4",
     "@nypl/dgx-svg-icons": "0.2.5",
     "@nypl/nypl-data-api-client": "0.2.5",
     "alt": "0.18.6",


### PR DESCRIPTION
[Related Jira ticket](https://jira.nypl.org/browse/RENO-1153)

**This PR does the following:**

- Updates dgx-react-footer to v0.5.4
- The footer update removes the Kievit font, Tumbler icon, and adds [system-font-css](https://github.com/jonathantneal/system-font-css) according to this [migration guide](https://docs.google.com/document/d/1gErDfbmTuKvSUkmfFnhRh9BAF1CCqUl66koTAtOZmdU/edit#)